### PR TITLE
Allow fetching raw content image for use with n-image

### DIFF
--- a/server/lib/types/content.js
+++ b/server/lib/types/content.js
@@ -92,6 +92,13 @@ const Image = new GraphQLObjectType({
 				return `//next-geebee.ft.com/image/v1/images/raw/${it.url}?source=next&fit=scale-down&width=${width}`;
 			}
 		},
+		rawSrc: {
+			type: GraphQLString,
+			description: 'Original source URL of the image',
+			resolve: (it) => {
+				return it.url;
+			}
+		},
 		alt: {
 			type: GraphQLString,
 			description: 'Alternative text'


### PR DESCRIPTION
In order to fetch optimally sized images for the client's screen in an effort to reduce page size for slow networks.