### PR TITLE
Cache CAPI articles individually

### DIFF
--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -31,23 +31,29 @@ class CAPI {
 	}
 
 	contentv1(uuids) {
-		return this.cache.cached(`${this.type}.contentv1.${Array.isArray(uuids) ? uuids.join('_') : uuids}`, 50, () => {
-			return ApiClient.contentLegacy({
-				uuid: uuids,
-				useElasticSearch: this.elasticSearch,
-				useElasticSearchOnAws: this.elasticSearchAws
+		const promises = [].concat(uuids).map(function(uuid) {
+			return this.cache.cached(`${this.type}.contentv1.${uuid}`, 50, () => {
+				return ApiClient.contentLegacy({
+					uuid: uuid,
+					useElasticSearch: this.elasticSearch,
+					useElasticSearchOnAws: this.elasticSearchAws
+				});
 			});
-		});
+		}.bind(this));
+		return Promise.all(promises);
 	}
 
 	contentv2(uuids) {
-		return this.cache.cached(`${this.type}.contentv2.${uuids.join('_')}`, 50, () => {
-			return ApiClient.content({
-				uuid: uuids,
-				useElasticSearch: this.elasticSearch,
-				useElasticSearchOnAws: this.elasticSearchAws
+		const promises = [].concat(uuids).map(function(uuid) {
+			return this.cache.cached(`${this.type}.contentv2.${uuid}`, 50, () => {
+				return ApiClient.content({
+					uuid: uuid,
+					useElasticSearch: this.elasticSearch,
+					useElasticSearchOnAws: this.elasticSearchAws
+				});
 			});
-		});
+		}.bind(this));
+		return Promise.all(promises);
 	}
 
 	list(uuid, ttl = 50) {

--- a/test/server/lib/backend.test.js
+++ b/test/server/lib/backend.test.js
@@ -30,7 +30,10 @@ describe('GraphQL Backend', () => {
 
 			return stories.then((it) => {
 				expect(it.length).to.eq(3);
-			});
+				return stories.then((it) => {
+					expect(it.length).to.eq(3);	
+				});
+			})
 		});
 
 		it('filters stories by genre', () => {


### PR DESCRIPTION
/cc @charypar @matthew-andrews 

Addresses https://github.com/Financial-Times/next-graphql-api/issues/21
In theory, this should mean less repetition in the cache => Lower memory usage. Should be able to verify this overnight, when GraphQL has been running for a long time.

Downside to the implementation here is that initially we'd be making 10 requests to elastic search instead of one, but probably worth it for the more effective cache hit ratio.