### PR TITLE
Add smoke test for graphql query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,8 @@ run:
 	nbt run
 
 provision:
-	nbt float
+	nbt float --testapp ${TEST_APP}
 	nbt deploy-hashed-assets
-	nbt test-urls ${TEST_APP}
 
 tidy:
 	# `nbt float` now tidies up after itself

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ run:
 provision:
 	nbt float
 	nbt deploy-hashed-assets
+	nbt test-urls ${TEST_APP}
 
 tidy:
 	# `nbt float` now tidies up after itself

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,12 @@ run:
 	nbt run
 
 provision:
-	nbt float --testapp ${TEST_APP}
+	nbt float -md --testapp ${TEST_APP}
 	nbt deploy-hashed-assets
+	nbt test-urls ${TEST_APP}
 
 tidy:
-	# `nbt float` now tidies up after itself
+	nbt destroy ${TEST_APP}
 
 deploy:
 	nbt ship -m

--- a/server/init.js
+++ b/server/init.js
@@ -20,7 +20,8 @@ app.get('/__gtg', (req, res) => {
 });
 
 app.use((req, res, next) => {
-	if (!req.query.apiKey || req.query.apiKey !== process.env.GRAPHQL_API_KEY) {
+	const apiKey = req.headers['x-api-key'] || req.query.apiKey;
+	if (!apiKey || apiKey !== process.env.GRAPHQL_API_KEY) {
 		logger.error('Bad or missing apiKey');
 		res.status(401).send('Bad or missing apiKey');
 	} else {

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -67,15 +67,16 @@ module.exports = [
 	{
 		headers: {
 			'Accept': 'application/json',
-			'Content-Type': 'application/json'
+			'Content-Type': 'application/json',
+			'X-API-KEY': process.env.GRAPHQL_API_KEY
 		},
 		method: 'POST',
 		body: JSON.stringify({
 			query: query
 		}),
 		timeout: 8000,
-		urls: {}
+		urls: {
+			'/': 200
+		}
 	}
 ];
-
-module.exports[0].urls[`/?apiKey=${process.env.GRAPHQL_API_KEY}`] = 200;

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const query = `
+	fragment Basic on Content {
+	    type: __typename
+	    contentType
+	    id
+	    title
+	    lastPublished
+	}
+
+	fragment Extended on Content {
+	    genre
+	    summary
+	    primaryTag {
+	        id
+	        url
+	        taxonomy
+	        name
+	    }
+	    primaryImage {
+	        src(width: 710)
+	        alt
+	    }
+	}
+
+	fragment Related on Content {
+	    relatedContent(limit: 3) {
+	        id
+	        title
+	        genre
+	        primaryTag {
+	            id
+	            url
+	            taxonomy
+	            name
+	        }
+	    }
+	}
+
+	query TopStoriesTest {
+	    popularTopics {
+	        name
+	        url
+	    }
+	    top(region: UK) {
+	        leads: items(limit: 1, type: Article) {
+	            ... Basic
+	            ... Extended
+	            ... Related
+	        }
+	        liveBlogs: items(type: LiveBlog) {
+	            ... Basic
+	            ... Extended
+	            ... on LiveBlog {
+	                status
+	                updates(limit: 1) {
+	                    date
+	                    text
+	                }
+	            }
+	        }
+	        items(from: 1, type: Article) {
+	            ... Basic
+	            ... Extended
+	        }
+	    }
+	}
+	`;
+
+
+module.exports = [
+	{
+		headers: {
+			'Accept': 'application/json',
+    	'Content-Type': 'application/json'
+		},
+		method: 'POST',
+		body: JSON.stringify({
+			query: query
+		}),
+		timeout: 8000,
+		urls: {}
+	}
+];
+
+module.exports[0].urls[`/?apiKey=${process.env.GRAPHQL_API_KEY}`] = 200;

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,72 +1,66 @@
 'use strict';
 
 const query = `
-	fragment Basic on Content {
-			type: __typename
-			contentType
+	query GraphQLSmoke {
+		popularTopics {
+			name
+		}
+		top(region: UK) {
+			lead: items(limit: 1, type: Article) {
+				title
+			}
+			liveBlogs: items(type: LiveBlog) {
+				title
+			}
+			items(from: 1, type: Article) {
+				title
+			}
+		}
+		fastFT {
+			items(limit: 5) {
+				title
+			}
+		}
+		editorsPicks {
+			title
+			items(limit: 6) {
+				title
+			}
+		}
+		opinion {
+			url
+			items {
+				title
+			}
+		}
+		lifestyle {
+			url
+			items(limit: 2) {
+				title
+			}
+		}
+		markets {
+			url
+			items(limit: 2, genres: ["analysis", "comment"]) {
+				title
+			}
+		}
+		technology {
+			url
+			items(limit: 2, genres: ["analysis", "comment"]) {
+				title
+			}
+		}
+		popular {
+			items(limit: 10) {
+				title
+			}
+		}
+		videos {
 			id
 			title
-			lastPublished
-	}
-
-	fragment Extended on Content {
-			genre
-			summary
-			primaryTag {
-					id
-					url
-					taxonomy
-					name
-			}
-			primaryImage {
-					src(width: 710)
-					alt
-			}
-	}
-
-	fragment Related on Content {
-			relatedContent(limit: 3) {
-					id
-					title
-					genre
-					primaryTag {
-							id
-							url
-							taxonomy
-							name
-					}
-			}
-	}
-
-	query TopStoriesTest {
-			popularTopics {
-					name
-					url
-			}
-			top(region: UK) {
-					leads: items(limit: 1, type: Article) {
-							... Basic
-							... Extended
-							... Related
-					}
-					liveBlogs: items(type: LiveBlog) {
-							... Basic
-							... Extended
-							... on LiveBlog {
-									status
-									updates(limit: 1) {
-											date
-											text
-									}
-							}
-					}
-					items(from: 1, type: Article) {
-							... Basic
-							... Extended
-					}
-			}
-	}
-	`;
+		}
+	}`;
 
 
 module.exports = [

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -2,69 +2,69 @@
 
 const query = `
 	fragment Basic on Content {
-	    type: __typename
-	    contentType
-	    id
-	    title
-	    lastPublished
+			type: __typename
+			contentType
+			id
+			title
+			lastPublished
 	}
 
 	fragment Extended on Content {
-	    genre
-	    summary
-	    primaryTag {
-	        id
-	        url
-	        taxonomy
-	        name
-	    }
-	    primaryImage {
-	        src(width: 710)
-	        alt
-	    }
+			genre
+			summary
+			primaryTag {
+					id
+					url
+					taxonomy
+					name
+			}
+			primaryImage {
+					src(width: 710)
+					alt
+			}
 	}
 
 	fragment Related on Content {
-	    relatedContent(limit: 3) {
-	        id
-	        title
-	        genre
-	        primaryTag {
-	            id
-	            url
-	            taxonomy
-	            name
-	        }
-	    }
+			relatedContent(limit: 3) {
+					id
+					title
+					genre
+					primaryTag {
+							id
+							url
+							taxonomy
+							name
+					}
+			}
 	}
 
 	query TopStoriesTest {
-	    popularTopics {
-	        name
-	        url
-	    }
-	    top(region: UK) {
-	        leads: items(limit: 1, type: Article) {
-	            ... Basic
-	            ... Extended
-	            ... Related
-	        }
-	        liveBlogs: items(type: LiveBlog) {
-	            ... Basic
-	            ... Extended
-	            ... on LiveBlog {
-	                status
-	                updates(limit: 1) {
-	                    date
-	                    text
-	                }
-	            }
-	        }
-	        items(from: 1, type: Article) {
-	            ... Basic
-	            ... Extended
-	        }
-	    }
+			popularTopics {
+					name
+					url
+			}
+			top(region: UK) {
+					leads: items(limit: 1, type: Article) {
+							... Basic
+							... Extended
+							... Related
+					}
+					liveBlogs: items(type: LiveBlog) {
+							... Basic
+							... Extended
+							... on LiveBlog {
+									status
+									updates(limit: 1) {
+											date
+											text
+									}
+							}
+					}
+					items(from: 1, type: Article) {
+							... Basic
+							... Extended
+					}
+			}
 	}
 	`;
 
@@ -73,7 +73,7 @@ module.exports = [
 	{
 		headers: {
 			'Accept': 'application/json',
-    	'Content-Type': 'application/json'
+			'Content-Type': 'application/json'
 		},
 		method: 'POST',
 		body: JSON.stringify({


### PR DESCRIPTION
/cc @charypar @ironsidevsquincy @andygout 
Hopefully make it less likely to break stuff on deploys :see_no_evil: 
* Also adds the ability to specify API key as a header

TODO:
- [x] [PR for next-build-tools to allow for POST requests](https://github.com/Financial-Times/next-build-tools/pull/287)
- [x] PR to config vars to add api key to continuous integration env
- [x] Add step to makefile