### PR TITLE
[On Hold] Batch cache fetch

### DIFF
--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -31,31 +31,28 @@ class CAPI {
 	}
 
 	contentv1(uuids) {
-		const promises = [].concat(uuids).map((uuid) => {
-			return this.cache.cached(`${this.type}.contentv1.${uuid}`, 50, () => {
-				return ApiClient.contentLegacy({
-					uuid: uuid,
-					useElasticSearch: this.elasticSearch,
-					useElasticSearchOnAws: this.elasticSearchAws
-				});
+
+		const listPromise = this.cache.cachedList(`${this.type}.contentv1`, uuids, 50, (uuids) => {
+			return ApiClient.contentLegacy({
+				uuid: uuids,
+				useElasticSearch: this.elasticSearch,
+				useElasticSearchOnAws: this.elasticSearchAws
 			});
 		});
-		return Promise.all(promises).then((items) => {
+		return listPromise.then((items) => {
 			return items.filter(item => !!item);
 		});
 	}
 
 	contentv2(uuids) {
-		const promises = [].concat(uuids).map((uuid) => {
-			return this.cache.cached(`${this.type}.contentv2.${uuid}`, 50, () => {
-				return ApiClient.content({
-					uuid: uuid,
-					useElasticSearch: this.elasticSearch,
-					useElasticSearchOnAws: this.elasticSearchAws
-				});
+		const listPromise = this.cache.cachedList(`${this.type}.contentv2`, uuids, 50, (uuids) => {
+			return ApiClient.content({
+				uuid: uuids,
+				useElasticSearch: this.elasticSearch,
+				useElasticSearchOnAws: this.elasticSearchAws
 			});
 		});
-		return Promise.all(promises).then((items) => {
+		return listPromise.then((items) => {
 			return items.filter(item => !!item);
 		});
 	}

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -39,8 +39,8 @@ class Cache {
 			metrics.count(`cacher.${metricsKey}.cached`, 1);
 			return Promise.resolve(data);
 		}
-		// we don't have fresh data, fetch it
-		const eventualData = this._fetch(key, now, ttl, fetcher);
+		// we don't have fresh data, fetch it and cache it
+		const eventualData = this._fetch(key, null, now, ttl, fetcher);
 
 		// return stale data or promise of fresh data
 		if(data) {
@@ -51,33 +51,93 @@ class Cache {
 		}
 	}
 
-	_fetch(key, now, ttl, fetcher) {
-		const metricsKey = key.split('.')[0];
+	// Caching for lists. For a given list of IDs, cache the IDs individually, but fetch in a batch
+	// when cache expires return stale data immediately and fetches fresh one
+	cachedList(listKey, ids, ttl, batchFetcher) {
+		const promises = new Map();
+		const itemsToFetch = [];
+		const itemsToWaitFor = [];
+		const cache = this.contentCache;
+		const now = (new Date().getTime()) / 1000;
+		let requiredFetches = 0;
+		let eventualData;
 
-		if(this.requestMap[key])
-			return this.requestMap[key];
+		ids.forEach((id) => {
+			let itemCacheKey = `${listKey}.${id}`;
+			let data = cache[itemCacheKey] && cache[itemCacheKey].data;
+			let expire = cache[itemCacheKey] && cache[itemCacheKey].expire;
+			if(expire > now && data) {
+				//we have fresh data
+				promises.set(id, data);
+			} else {
+				itemsToFetch.push(id);
+				if(data) {
+					promises.set(id, data);
+				} else {
+					promises.set(id, null);
+					itemsToWaitFor.push(id);
+				}
+			}
+		});
+
+		if(itemsToFetch.length) {
+
+			eventualData =
+				this._fetch(listKey, itemsToFetch, now, ttl, batchFetcher)
+				.then((items) => {
+					if(items) {
+						items.forEach((item, index) => {
+							promises.set(itemsToWaitFor[index], item);
+						});
+					}
+					return [...promises.values()];
+				})
+		}
+
+		if(itemsToWaitFor.length) {
+			return eventualData;
+		} else {
+			return Promise.resolve([...promises.values()]);
+		}
+
+	}
+
+	_fetch(key, ids, now, ttl, fetcher) {
+		const requestKey = ids && ids.length ? `${key}.${ids.join('_')}` : key;
+		const metricsKey = key.split('.')[0];
+		const expireTime = now + ttl;
+		if(this.requestMap[requestKey])
+			return this.requestMap[requestKey];
 
 		metrics.count(`cacher.${metricsKey}.fresh`, 1);
 
-		this.requestMap[key] = fetcher()
+		this.requestMap[requestKey] = fetcher(ids)
 		.then((it) => {
-			let expireTime = now + ttl;
+			if(ids && ids.length) {
+				it.forEach((item, index) => {
+					let itemCacheKey = `${key}.${ids[index]}`;
+					if(item) {
+						this.contentCache[itemCacheKey] = {
+							expire: expireTime,
+							data: item
+						};
+					}
+				});
+			} else {
+				this.contentCache[key] = {
+					expire: expireTime,
+					data: it
+				};
+			}
 
-			this.contentCache[key] = {
-				expire: expireTime,
-				data: it
-			};
-
-			delete this.requestMap[key];
-
+			delete this.requestMap[requestKey];
 			return it;
 		})
 		.catch((err) => {
 			metrics.count(`cacher.${metricsKey}.error`, 1);
-			delete this.requestMap[key];
-			logger.error(err);
+			delete this.requestMap[requestKey];
 		});
-		return this.requestMap[key];
+		return this.requestMap[requestKey];
 	}
 }
 

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -59,7 +59,6 @@ class Cache {
 		const itemsToWaitFor = [];
 		const cache = this.contentCache;
 		const now = (new Date().getTime()) / 1000;
-		let requiredFetches = 0;
 		let eventualData;
 
 		ids.forEach((id) => {
@@ -135,6 +134,7 @@ class Cache {
 		})
 		.catch((err) => {
 			metrics.count(`cacher.${metricsKey}.error`, 1);
+			logger.error(err);
 			delete this.requestMap[requestKey];
 		});
 		return this.requestMap[requestKey];

--- a/test/server/lib/backend.test.js
+++ b/test/server/lib/backend.test.js
@@ -31,7 +31,7 @@ describe('GraphQL Backend', () => {
 			return stories.then((it) => {
 				expect(it.length).to.eq(3);
 				return stories.then((it) => {
-					expect(it.length).to.eq(3);	
+					expect(it.length).to.eq(3);
 				});
 			})
 		});

--- a/test/server/lib/cache.test.js
+++ b/test/server/lib/cache.test.js
@@ -11,15 +11,16 @@ import Cache from '../../../server/lib/cache';
 
 describe('GraphQL Cache', () => {
 	const cache = new Cache(10);
-	const fetcher = () => {
-		return Promise.resolve('fresh');
-	};
-	const fail = () => {
-		return Promise.reject('OMG');
-	};
 
 
 	describe('#cached', () => {
+		const fetcher = () => {
+			return Promise.resolve('fresh');
+		};
+		const fail = () => {
+			return Promise.reject('OMG');
+		};
+
 		it('fetches fresh data when nothing is cached', () => {
 			expect(cache.cached('test-key-1', 1, fetcher)).to.eventually.eq('fresh');
 		});
@@ -76,6 +77,91 @@ describe('GraphQL Cache', () => {
 				return p2.then(() => {
 					cache.clear('test-key-6');
 					p3 = cache.cached('test-key-6', 10, fetcher);
+
+					// now they shouldn't be the same promise
+					expect(p1).to.not.equal(p2);
+					expect(p1).to.not.equal(p3);
+					expect(p2).to.not.equal(p3);
+				})
+			});
+		});
+	});
+
+
+	describe('#cachedList', () => {
+		const fetcher = () => {
+			return Promise.resolve(['fresh', 'more-fresh']);
+		};
+		const fail = () => {
+			return Promise.reject('OMG');
+		};
+
+		it('fetches fresh data when nothing is cached', () => {
+			expect(cache.cachedList('test-key-1', [1,2], 10, fetcher)).to.eventually.eql(['fresh', 'more-fresh']);
+		});
+
+		it('returns cached data when fresh', () => {
+			return cache.cachedList('test-key-2', [1,2], 10, () => Promise.resolve(['orig1', 'orig2']))
+			.then(() => {
+				return cache.cachedList('test-key-2', [1,2], 10, fetcher)
+			})
+			.then((it) => {
+				expect(it).to.eql(['orig1', 'orig2']);
+			});
+		});
+
+		it('[1,2], [2,3] only fetches 3 the second time round', () => {
+			return cache.cachedList('test-key-3', [1,2], 10, () => Promise.resolve(['orig1', 'orig2']))
+			.then(() => {
+				return cache.cachedList('test-key-3', [2,3], 10, () => Promise.resolve(['fresh3']))
+			})
+			.then((it) => {
+				expect(it).to.eql(['orig2', 'fresh3']);
+			});
+		});
+
+		it('returns stale data when expired', () => {
+			return cache.cachedList('test-key-4', [1,2], -1, () => Promise.resolve(['stale1', 'stale2']))
+			.then(() => {
+				return cache.cachedList('test-key-4', [2,3], 10, () => Promise.resolve(['fresh3']));
+			})
+			.then((it) => {
+				expect(it).to.eql(['stale2', 'fresh3']);
+			})
+		});
+
+		it('fetches new data when cache expires', () => {
+			return cache.cachedList('test-key-5', [1,2], -10, () => Promise.resolve(['stale1', 'stale2']))
+			.then(() => {
+				return cache.cachedList('test-key-5', [1,2], 10, fetcher);
+			})
+			.then((it) => {
+				expect(it).to.eql(['stale1', 'stale2']);
+				return cache.cachedList('test-key-5', [1,2], 10, () => Promise.resolve(['too fresh 1', 'too fresh 2']));
+			})
+			.then((it) => {
+				expect(it).to.eql(['fresh', 'more-fresh']);
+			})
+		});
+
+		it('only fetches new data once at a time when cache expires', () => {
+			let p1 = cache.cachedList('test-key-6', [1,2], 10, fetcher);
+			let p2 = cache.cachedList('test-key-6', [1,2], 10, fetcher);
+			// both should be the same promise
+			expect(p1).to.eql(p2);
+		});
+
+		it('clean up finished and failed fetches', () => {
+			let p3 = null;
+			let p1 = cache.cachedList('test-key-6', [1,2], -1, fail)
+
+			return p1.then(() => {
+				let p2 = cache.cachedList('test-key-6', [2,3], -1, fetcher)
+
+				return p2.then(() => {
+					cache.clear('test-key-6.1');
+					cache.clear('test-key-6.2');
+					p3 = cache.cachedList('test-key-6', [1,2], 10, fetcher);
 
 					// now they shouldn't be the same promise
 					expect(p1).to.not.equal(p2);

--- a/test/server/lib/capi.test.js
+++ b/test/server/lib/capi.test.js
@@ -1,0 +1,88 @@
+import realFetch from 'isomorphic-fetch';
+global.fetch = realFetch;
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+import contentv1fixture from './fixtures/contentv1';
+import listfixture from './fixtures/list';
+
+import ApiClient from 'next-ft-api-client';
+import Cache from '../../../server/lib/cache';
+import CAPI from '../../../server/lib/backend-adapters/capi';
+
+
+describe('CAPI backend', () => {
+	describe('#contentv1', () => {
+		const cache = new Cache(10);
+		const testCAPIBackend = new CAPI(cache, {});
+		let stubAPI;
+
+		before(() => {
+			stubAPI = sinon.stub(ApiClient, 'contentLegacy', (opts) => {
+				switch(opts.uuid) {
+					case 'valid':
+						return Promise.resolve(contentv1fixture[0]);
+					case 'invalid':
+						return Promise.reject('bad response');
+					case 'another-valid':
+						return Promise.resolve(contentv1fixture[1]);
+					default:
+						return Promise.resolve(contentv1fixture[2]);
+				}
+			});
+		});
+
+		afterEach(() => {
+			stubAPI.reset();
+			Object.keys(cache.contentCache).forEach(key => cache.clear(key));
+		});
+
+		after(() => {
+			stubAPI.restore();
+		})
+
+		it('fetches stories', () => {
+			const stories = testCAPIBackend.contentv1(['valid', 'another-valid']);
+
+			return stories.then((it) => {
+				expect(stubAPI.callCount).to.eq(2);
+				expect(it.length).to.eq(2);
+			});
+		});
+
+		it('handles bad responses from CAPI', () => {
+			const stories = testCAPIBackend.contentv1(['valid', 'invalid', 'another-valid']);
+
+			return stories.then((it) => {
+				expect(stubAPI.callCount).to.eq(3);
+				expect(it.length).to.eq(2);
+			});
+		});
+
+
+		it('only requests each article once', () => {
+			const firstBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
+			return firstBatch.then((it) => {
+				expect(stubAPI.callCount).to.eq(2);
+				expect(it.length).to.eq(2);
+				expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
+				expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
+				const secondBatch = testCAPIBackend.contentv1(['another-valid', 'valid-3']);
+
+				return secondBatch.then((it) => {
+					expect(stubAPI.callCount).to.eq(3);
+					expect(it.length).to.eq(2);
+					expect(it[0].item.metadata.genre[0].term.name).to.eq('Market Report');
+					expect(it[1].item.metadata.genre[0].term.name).to.eq('Comment');
+				});
+			})
+		});
+
+
+
+	})
+});

--- a/test/server/lib/capi.test.js
+++ b/test/server/lib/capi.test.js
@@ -8,7 +8,6 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 import contentv1fixture from './fixtures/contentv1';
-import listfixture from './fixtures/list';
 
 import ApiClient from 'next-ft-api-client';
 import Cache from '../../../server/lib/cache';
@@ -24,7 +23,6 @@ describe.only('CAPI backend', () => {
 
 		before(() => {
 			stubAPI = sinon.stub(ApiClient, 'contentLegacy', (opts) => {
-				console.log(opts)
 				return Promise.resolve(opts.uuid.map((uuid) => {
 					switch(uuid) {
 						case 'valid':

--- a/test/server/lib/capi.test.js
+++ b/test/server/lib/capi.test.js
@@ -15,7 +15,8 @@ import Cache from '../../../server/lib/cache';
 import CAPI from '../../../server/lib/backend-adapters/capi';
 
 
-describe('CAPI backend', () => {
+
+describe.only('CAPI backend', () => {
 	describe('#contentv1', () => {
 		const cache = new Cache(10);
 		const testCAPIBackend = new CAPI(cache, {});
@@ -23,16 +24,19 @@ describe('CAPI backend', () => {
 
 		before(() => {
 			stubAPI = sinon.stub(ApiClient, 'contentLegacy', (opts) => {
-				switch(opts.uuid) {
-					case 'valid':
-						return Promise.resolve(contentv1fixture[0]);
-					case 'invalid':
-						return Promise.reject('bad response');
-					case 'another-valid':
-						return Promise.resolve(contentv1fixture[1]);
-					default:
-						return Promise.resolve(contentv1fixture[2]);
-				}
+				console.log(opts)
+				return Promise.resolve(opts.uuid.map((uuid) => {
+					switch(uuid) {
+						case 'valid':
+							return contentv1fixture[0];
+						case 'invalid':
+							return null;
+						case 'another-valid':
+							return contentv1fixture[1];
+						default:
+							return contentv1fixture[2];
+						}
+				}));
 			});
 		});
 
@@ -49,7 +53,7 @@ describe('CAPI backend', () => {
 			const stories = testCAPIBackend.contentv1(['valid', 'another-valid']);
 
 			return stories.then((it) => {
-				expect(stubAPI.callCount).to.eq(2);
+				expect(stubAPI.callCount).to.eq(1);
 				expect(it.length).to.eq(2);
 			});
 		});
@@ -58,28 +62,48 @@ describe('CAPI backend', () => {
 			const stories = testCAPIBackend.contentv1(['valid', 'invalid', 'another-valid']);
 
 			return stories.then((it) => {
-				expect(stubAPI.callCount).to.eq(3);
+				expect(stubAPI.callCount).to.eq(1);
 				expect(it.length).to.eq(2);
 			});
 		});
 
 
-		it('only requests each article once', () => {
+		it('caching - [a,b], [a,b] makes no requests the second time round ', () => {
 			const firstBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
 			return firstBatch.then((it) => {
-				expect(stubAPI.callCount).to.eq(2);
+				expect(stubAPI.callCount).to.eq(1);
+				expect(stubAPI.args[0][0].uuid).to.eql(['valid', 'another-valid']);
+				expect(it.length).to.eq(2);
+				expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
+				expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
+				const secondBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
+
+				return secondBatch.then((it) => {
+					expect(stubAPI.callCount).to.eq(1);
+					expect(it.length).to.eq(2);
+				expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
+				expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
+				});
+			});
+		});
+		it('caching - [a,b], [b,c] only fetches c the second time round', () => {
+			const firstBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
+			return firstBatch.then((it) => {
+				expect(stubAPI.callCount).to.eq(1);
+				expect(stubAPI.args[0][0].uuid).to.eql(['valid', 'another-valid']);
 				expect(it.length).to.eq(2);
 				expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
 				expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
 				const secondBatch = testCAPIBackend.contentv1(['another-valid', 'valid-3']);
 
 				return secondBatch.then((it) => {
-					expect(stubAPI.callCount).to.eq(3);
+					expect(stubAPI.callCount).to.eq(2);
+					expect(stubAPI.args[1][0].uuid).to.eql(['valid-3']);
 					expect(it.length).to.eq(2);
 					expect(it[0].item.metadata.genre[0].term.name).to.eq('Market Report');
 					expect(it[1].item.metadata.genre[0].term.name).to.eq('Comment');
 				});
-			})
+			});
 		});
 
 


### PR DESCRIPTION
This PR maintains the benefit of batched requests to CAPI whilst still caching individual articles.

Number of fetches on a clean startup reduced from ~114 to ~22.

TODO:
- [ ] Add some comments to the code, and maybe tidy up a little
- [ ] Compare against production results
 