### PR TITLE
Revert the individual item fetching back to letting ES do the whole b…

### DIFF
--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -25,24 +25,18 @@ class CAPI {
 	}
 
 	contentv1(uuids) {
-		const promises = [].concat(uuids).map((uuid) => {
-			return this.cache.cached(`${this.type}.contentv1.${uuid}`, 50, () => {
-				return ApiClient.contentLegacy({ uuid: uuid });
+		return this.cache.cached(`${this.type}.contentv1.${Array.isArray(uuids) ? uuids.join('_') : uuids}`, 50, () => {
+			return ApiClient.contentLegacy({
+				uuid: uuids
 			});
-		});
-		return Promise.all(promises).then((items) => {
-			return items.filter(item => !!item);
 		});
 	}
 
 	contentv2(uuids) {
-		const promises = [].concat(uuids).map((uuid) => {
-			return this.cache.cached(`${this.type}.contentv2.${uuid}`, 50, () => {
-				return ApiClient.content({ uuid: uuid });
+		return this.cache.cached(`${this.type}.contentv2.${uuids.join('_')}`, 50, () => {
+			return ApiClient.content({
+				uuid: uuids
 			});
-		});
-		return Promise.all(promises).then((items) => {
-			return items.filter(item => !!item);
 		});
 	}
 

--- a/test/server/lib/capi.test.js
+++ b/test/server/lib/capi.test.js
@@ -23,16 +23,10 @@ describe('CAPI backend', () => {
 
 		before(() => {
 			stubAPI = sinon.stub(ApiClient, 'contentLegacy', (opts) => {
-				switch(opts.uuid) {
-					case 'valid':
-						return Promise.resolve(contentv1fixture[0]);
-					case 'invalid':
-						return Promise.reject('bad request');
-					case 'another-valid':
-						return Promise.resolve(contentv1fixture[1]);
-					default:
-						return Promise.resolve(contentv1fixture[2]);
-					}
+				if(opts.uuid.includes('invalid')) {
+					return Promise.reject('Fetch failed');
+				}
+				return Promise.resolve(contentv1fixture);
 			});
 		});
 
@@ -49,8 +43,8 @@ describe('CAPI backend', () => {
 			const stories = testCAPIBackend.contentv1(['valid', 'another-valid']);
 
 			return stories.then((it) => {
-				expect(stubAPI.callCount).to.eq(2);
-				expect(it.length).to.eq(2);
+				expect(stubAPI.callCount).to.eq(1);
+				expect(it.length).to.eq(3);
 			});
 		});
 
@@ -58,48 +52,47 @@ describe('CAPI backend', () => {
 			const stories = testCAPIBackend.contentv1(['valid', 'invalid', 'another-valid']);
 
 			return stories.then((it) => {
-				expect(stubAPI.callCount).to.eq(3);
-				expect(it.length).to.eq(2);
+				expect(stubAPI.callCount).to.eq(1);
+				expect(it).to.be.undefined;
 			});
 		});
 
 
-		it('caching - [a,b], [a,b] makes no requests the second time round ', () => {
-			const firstBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
+		it('caching - [a,b, c], [a,b,c] makes no requests the second time round ', () => {
+			const firstBatch = testCAPIBackend.contentv1(['a', 'b', 'c']);
 			return firstBatch.then((it) => {
-				expect(stubAPI.callCount).to.eq(2);
-				expect(stubAPI.args[0][0].uuid).to.eq('valid');
-				expect(stubAPI.args[1][0].uuid).to.eq('another-valid');
-				expect(it.length).to.eq(2);
+				expect(stubAPI.callCount).to.eq(1);
+				expect(stubAPI.args[0][0].uuid).to.eql(['a', 'b', 'c']);
+				expect(it.length).to.eq(3);
 				expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
 				expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
-				const secondBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
+				const secondBatch = testCAPIBackend.contentv1(['a', 'b', 'c']);
 
 				return secondBatch.then((it) => {
-					expect(stubAPI.callCount).to.eq(2);
-					expect(it.length).to.eq(2);
+					expect(stubAPI.callCount).to.eq(1);
+					expect(it.length).to.eq(3);
 					expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
 					expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
 				});
 			});
 		});
-		it('caching - [a,b], [b,c] only fetches c the second time round', () => {
-			const firstBatch = testCAPIBackend.contentv1(['valid', 'another-valid']);
+
+		it('caching - [a,b,c], [b,c,d] makes a fetch the second time round', () => {
+			const firstBatch = testCAPIBackend.contentv1(['a', 'b', 'c']);
 			return firstBatch.then((it) => {
-				expect(stubAPI.callCount).to.eq(2);
-				expect(stubAPI.args[0][0].uuid).to.eq('valid');
-				expect(stubAPI.args[1][0].uuid).to.eq('another-valid');
-				expect(it.length).to.eq(2);
+				expect(stubAPI.callCount).to.eq(1);
+				expect(stubAPI.args[0][0].uuid).to.eql(['a', 'b', 'c']);
+				expect(it.length).to.eq(3);
 				expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
 				expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
-				const secondBatch = testCAPIBackend.contentv1(['another-valid', 'valid-3']);
+				const secondBatch = testCAPIBackend.contentv1(['b', 'c', 'd']);
 
 				return secondBatch.then((it) => {
-					expect(stubAPI.callCount).to.eq(3);
-					expect(stubAPI.args[2][0].uuid).to.eq('valid-3');
-					expect(it.length).to.eq(2);
-					expect(it[0].item.metadata.genre[0].term.name).to.eq('Market Report');
-					expect(it[1].item.metadata.genre[0].term.name).to.eq('Comment');
+					expect(stubAPI.callCount).to.eq(2);
+					expect(stubAPI.args[1][0].uuid).to.eql(['b', 'c', 'd']);
+					expect(it.length).to.eq(3);
+					expect(it[0].item.metadata.genre[0].term.name).to.eq('Analysis');
+					expect(it[1].item.metadata.genre[0].term.name).to.eq('Market Report');
 				});
 			});
 		});


### PR DESCRIPTION
…unch

The initial change to cache articles individually made very little impact on memory usage anyway, and seems to cause the occasional spike in [hard-to-trace errors](https://app.getsentry.com/nextftcom/ft-next-graphql-api/group/89693436/)

So reverting back to the more stable ES fetching.

(incidentally fixes the mockFrontPage flag also :smile: )