### PR TITLE
Clear unused cache items

### DIFF
--- a/server/lib/backend.js
+++ b/server/lib/backend.js
@@ -160,8 +160,8 @@ class Backend {
 
 // Assemble the beast
 
-// serve stale cache for 12 hours
-const memCache = new Cache(12 * 60 * 60);
+// serve stale cache for 12 hours, and 30 minutes for unused items
+const memCache = new Cache(12 * 60 * 60, 30 * 60);
 
 // Adapters
 const fastFT = new FastFtFeed();

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -10,7 +10,7 @@ class Cache {
 		const sweeper = () => {
 			const now = (new Date().getTime()) / 1000;
 			for(let key in this.contentCache) {
-				if(this.contentCache[key].expire + staleTtl < now || 
+				if(this.contentCache[key].expire + staleTtl < now ||
 					this.contentCache[key].lastUsed + unusedStaleTtl < now) {
 					delete this.contentCache[key];
 				}
@@ -36,7 +36,7 @@ class Cache {
 		const expire = (cache[key] && cache[key].expire);
 		const now = (new Date().getTime()) / 1000;
 
-		if(cache[key]) {
+		if(data) {
 			cache[key].lastUsed = now;
 		}
 

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -1,16 +1,17 @@
 import { metrics, logger } from 'ft-next-express';
 
 class Cache {
-	constructor(staleTtl) {
+	constructor(staleTtl, unusedStaleTtl) {
 		// in-memory content cache
 		this.contentCache = {};
 		this.requestMap = {};
+		unusedStaleTtl = unusedStaleTtl || staleTtl;
 
 		const sweeper = () => {
 			const now = (new Date().getTime()) / 1000;
-
 			for(let key in this.contentCache) {
-				if(this.contentCache[key].expire + staleTtl < now) {
+				if(this.contentCache[key].expire + staleTtl < now || 
+					this.contentCache[key].lastUsed + unusedStaleTtl < now) {
 					delete this.contentCache[key];
 				}
 			}
@@ -34,6 +35,10 @@ class Cache {
 		const data = (cache[key] && cache[key].data);
 		const expire = (cache[key] && cache[key].expire);
 		const now = (new Date().getTime()) / 1000;
+
+		if(cache[key]) {
+			cache[key].lastUsed = now;
+		}
 
 		// we have fresh data
 		if(expire > now && data) {
@@ -63,9 +68,9 @@ class Cache {
 		this.requestMap[key] = fetcher()
 		.then((it) => {
 			let expireTime = now + ttl;
-
 			this.contentCache[key] = {
 				expire: expireTime,
+				lastUsed: now,
 				data: it
 			};
 

--- a/test/server/lib/cache.test.js
+++ b/test/server/lib/cache.test.js
@@ -93,9 +93,8 @@ describe('GraphQL Cache', () => {
 		const clock = sinon.useFakeTimers();
 		const cache = new Cache(10 * 60, 5 * 60);
 
-		const now = Date.now();
 
-		const p1 = cache.cached('test-key-1', Date.now() + 50, fetcher);
+		const p1 = cache.cached('test-key-1', 1, fetcher);
 		const p2 = cache.cached('test-key-unused', 1, fetcher);
 		return Promise.all([p1,p2]).then(() => {
 


### PR DESCRIPTION
Adds an unusedStaleTtl of 30 minutes, and any cache keys that haven't been accessed since that time will be cleared.

This should hopefully clear up memory used by old list of UUIDs.