### PR TITLE
Don't catch CAPI errors

### DIFF
--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -20,9 +20,6 @@ class CAPI {
 					sectionId: sectionsId,
 					items: it.slice()
 				}))
-				.catch(e => {
-					logger.error(`Error getting page ${uuid}`, e)
-				});
 		});
 	}
 
@@ -56,11 +53,8 @@ class CAPI {
 	}
 
 	list(uuid, ttl = 50) {
-		// NOTE: for now, list api is bronze, so handle errors
 		return this.cache.cached(`${this.type}.lists.${uuid}`, ttl, () => {
 			return ApiClient.lists({ uuid: uuid })
-			// return 'fake' list, so Collection can resolveType correctly
-			.catch(() => ({ apiUrl: `http://api.ft.com/lists/${uuid}` }));
 		});
 	}
 }

--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -2,8 +2,6 @@ import ApiClient from 'next-ft-api-client';
 import filterContent from '../helpers/filter-content';
 import resolveContentType from '../helpers/resolve-content-type';
 
-import { logger } from 'ft-next-express';
-
 
 class CAPI {
 	constructor(cache) {

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -83,8 +83,6 @@ class Cache {
 			delete this.requestMap[key];
 			logger.error(err);
 			
-			// Return stale content
-			return this.contentCache[key].data;
 		});
 		return this.requestMap[key];
 	}

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -82,6 +82,9 @@ class Cache {
 			metrics.count(`cache.${metricsKey}.error`, 1);
 			delete this.requestMap[key];
 			logger.error(err);
+			
+			// Return stale content
+			return this.contentCache[key].data;
 		});
 		return this.requestMap[key];
 	}

--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -67,6 +67,9 @@ class Cache {
 
 		this.requestMap[key] = fetcher()
 		.then((it) => {
+			if(!it) {
+				return;
+			}
 			let expireTime = now + ttl;
 			this.contentCache[key] = {
 				expire: expireTime,
@@ -82,7 +85,7 @@ class Cache {
 			metrics.count(`cache.${metricsKey}.error`, 1);
 			delete this.requestMap[key];
 			logger.error(err);
-			
+
 		});
 		return this.requestMap[key];
 	}

--- a/test/server/lib/cache.test.js
+++ b/test/server/lib/cache.test.js
@@ -46,6 +46,7 @@ describe('GraphQL Cache', () => {
 			})
 		});
 
+
 		it('fetches new data when cache expires', () => {
 			return cache.cached('test-key-4', -10, () => Promise.resolve('stale'))
 			.then(() => {
@@ -88,6 +89,31 @@ describe('GraphQL Cache', () => {
 		});
 	});
 
+
+		it('returns stale data on a fetch error', () => {
+			const clock = sinon.useFakeTimers();
+			const cache = new Cache(10 * 60, 5 * 60);
+			return cache.cached('test-key-7', -1, () => Promise.resolve('stale'))
+			.then(() => {
+				return cache.cached('test-key-7', 10, () => Promise.reject('error'));
+			})
+			.then((it) => {
+				//Stale object in cache, so ignore error and return that
+				expect(it).to.eq('stale');
+				clock.tick(1000 * 60 * 4);
+				return cache.cached('test-key-7', 10, () => Promise.reject('error'));
+			})
+			.then((it) => {
+				//After 6 minutes it is still being used, so return stale again
+				expect(it).to.eq('stale');
+				clock.tick(1000 * 60 * 11);
+				return cache.cached('test-key-7', 10, () => Promise.reject('error'));
+			})
+			.then((it) => {
+				//After 10 minutes we've cleared our cache, so give up and return undefined
+				expect(it).to.eq(undefined);	
+			})
+		});
 
 	it('cleans up cache items stale items and unused stale items seperately', () => {
 		const clock = sinon.useFakeTimers();


### PR DESCRIPTION
/cc @matthew-andrews @ironsidevsquincy 

Currently lists and pages catch their errors in the backend-adapter and returned undefined - which then get cached.
This change uncatches the errors so they are handled in fetcher - and ensures that undefined results never get cached.