### PR TITLE
Get hui results from past week instead of day

### DIFF
--- a/server/lib/backend-adapters/hui.js
+++ b/server/lib/backend-adapters/hui.js
@@ -7,9 +7,9 @@ class Hui {
 		this.cache = cache;
 	}
 
-	content({industry, position, sector, country, from, limit}, ttl = 50) {
-		return this.cache.cached(`${this.type}.${industry}.${position}.${sector}.${country}`, ttl, () => {
-			return ApiClient.hui({industry, position, sector, country, period: 'last-1-week'})
+	content({industry, position, sector, country, period='last-1-week', from, limit}, ttl = 50) {
+		return this.cache.cached(`${this.type}.${industry}.${position}.${sector}.${country}.${period}`, ttl, () => {
+			return ApiClient.hui({industry, position, sector, country, period})
 				.then(articles => sliceList(articles, {from, limit}));
 		});
 	}

--- a/server/lib/backend-adapters/hui.js
+++ b/server/lib/backend-adapters/hui.js
@@ -9,7 +9,7 @@ class Hui {
 
 	content({industry, position, sector, country, from, limit}, ttl = 50) {
 		return this.cache.cached(`${this.type}.${industry}.${position}.${sector}.${country}`, ttl, () => {
-			return ApiClient.hui({industry, position, sector, country})
+			return ApiClient.hui({industry, position, sector, country, period: 'last-1-week'})
 				.then(articles => sliceList(articles, {from, limit}));
 		});
 	}

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -154,6 +154,9 @@ const queryType = new GraphQLObjectType({
 				country: {
 					type: GraphQLString
 				},
+				period: {
+					type: GraphQLString
+				},
 				from: {
 					type: GraphQLInt
 				},


### PR DESCRIPTION
/cc @ironsidevsquincy @andygout @aRhombus 
Was playing around with the data, and getting most popular by industry for 1 week gives slightly more relevant results than 1 day (which tends to be just home page articles and not industry relevant).

The articles will be slightly more stale, but they were a day stale anyway, so I think it's a small price to pay for more relevance.