### PR TITLE
Layout hints

### DIFF
--- a/server/config/sources.js
+++ b/server/config/sources.js
@@ -5,6 +5,12 @@ const sources = {
 	usTop: {
 		uuid: 'b0ed86f4-4e94-11de-8d4c-00144feabdc0'
 	},
+	ukTopList: {
+		uuid: '520ddb76-e43d-11e4-9e89-00144feab7de'
+	},
+	usTopList: {
+		uuid: 'b0d8e4fe-10ff-11e5-8413-00144feabdc0'
+	},
 	fastFt: {
 		uuid: '5c7592a8-1f0c-11e4-b0cb-b2227cce2b54'
 	},

--- a/server/lib/health-checks/capi.js
+++ b/server/lib/health-checks/capi.js
@@ -11,8 +11,6 @@ class CapiCheck extends Check {
     }
 
     get checkOutput() {
-			console.log('this.status', this.status);
-
         switch (this.status) {
             case status.PENDING:
                 return 'This check has not yet run';
@@ -27,6 +25,10 @@ class CapiCheck extends Check {
         return api[this.capiMethod](this.capiOptions)
             .then(data => {
                 this.status = data ? status.PASSED : status.FAILED;
+                this.lastUpdated = new Date();
+            })
+            .catch(() => {
+                this.status = status.FAILED;
                 this.lastUpdated = new Date();
             });
     }

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -8,7 +8,7 @@ import {
 } from 'graphql';
 
 import { Region } from './types/basic';
-import { Collection } from './types/collections';
+import { Page, List, ContentByConcept, CombinedPageAndList } from './types/collections';
 import { Content, Video, Concept } from './types/content';
 import { ContentType } from './types/basic';
 import User from './types/user';
@@ -21,7 +21,7 @@ const queryType = new GraphQLObjectType({
 	description: 'FT content API',
 	fields: {
 		top: {
-			type: Collection,
+			type: CombinedPageAndList,
 			args: {
 				region: { type: new GraphQLNonNull(Region) }
 			},
@@ -33,13 +33,13 @@ const queryType = new GraphQLObjectType({
 			}
 		},
 		fastFT: {
-			type: Collection,
+			type: ContentByConcept,
 			resolve: (root, _, {rootValue: {flags}}) => {
 				return backend(flags).fastFT.fetch();
 			}
 		},
 		editorsPicks: {
-			type: Collection,
+			type: List,
 			resolve: (root, _, {rootValue: {flags}}) => {
 				if (flags && flags.editorsPicksFromList) {
 					return backend(flags).capi.list(sources['editorsPicks'].uuid);
@@ -49,7 +49,7 @@ const queryType = new GraphQLObjectType({
 			}
 		},
 		opinion: {
-			type: Collection,
+			type: Page,
 			resolve: (root, _, {rootValue: {flags}}) => {
 				let {uuid, sectionsId} = sources.opinion;
 
@@ -57,7 +57,7 @@ const queryType = new GraphQLObjectType({
 			}
 		},
 		lifestyle: {
-			type: Collection,
+			type: Page,
 			resolve: (root, _, {rootValue: {flags}}) => {
 				let {uuid, sectionsId} = sources.lifestyle;
 
@@ -65,7 +65,7 @@ const queryType = new GraphQLObjectType({
 			}
 		},
 		markets: {
-			type: Collection,
+			type: Page,
 			resolve: (root, _, {rootValue: {flags}}) => {
 				let {uuid, sectionsId} = sources.markets;
 
@@ -73,7 +73,7 @@ const queryType = new GraphQLObjectType({
 			}
 		},
 		technology: {
-			type: Collection,
+			type: Page,
 			resolve: (root, _, {rootValue: {flags}}) => {
 				let {uuid, sectionsId} = sources.technology;
 

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -28,7 +28,7 @@ const queryType = new GraphQLObjectType({
 			resolve: (root, {region}, {rootValue: {flags}}) => {
 				const uuid = sources[`${region}Top`].uuid;
 				const listUuid = sources[`${region}TopList`].uuid;
-				const listFetch = flags.frontPageMultipleLayouts ? backend(flags).capi.list(listUuid).catch(err => {}) : Promise.resolve({});
+				const listFetch = flags.frontPageMultipleLayouts ? backend(flags).capi.list(listUuid).catch(() => {}) : Promise.resolve({});
 				return Promise.all([backend(flags).capi.page(uuid), listFetch]);
 			}
 		},

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -26,8 +26,10 @@ const queryType = new GraphQLObjectType({
 				region: { type: new GraphQLNonNull(Region) }
 			},
 			resolve: (root, {region}, {rootValue: {flags}}) => {
-				let uuid = sources[`${region}Top`].uuid;
-				return backend(flags).capi.page(uuid);
+				const uuid = sources[`${region}Top`].uuid;
+				const listUuid = sources[`${region}TopList`].uuid;
+				const listFetch = flags.frontPageMultipleLayouts ? backend(flags).capi.list(listUuid).catch(err => {}) : Promise.resolve({});
+				return Promise.all([backend(flags).capi.page(uuid), listFetch]);
 			}
 		},
 		fastFT: {

--- a/server/lib/types/collections.js
+++ b/server/lib/types/collections.js
@@ -2,8 +2,7 @@ import {
 	GraphQLString,
 	GraphQLInt,
 	GraphQLList,
-	GraphQLObjectType,
-	GraphQLInterfaceType
+	GraphQLObjectType
 } from 'graphql';
 
 import { Content } from './content';

--- a/server/lib/types/collections.js
+++ b/server/lib/types/collections.js
@@ -54,7 +54,7 @@ const Page = new GraphQLObjectType({
 		},
 		layoutHint: {
 			type: GraphQLString,
-			resolve: ([page, list]) => list ? list.layoutHint : null
+			resolve: ([, list]) => list ? list.layoutHint : null
 		},
 		items: {
 			type: new GraphQLList(Content),

--- a/server/lib/types/collections.js
+++ b/server/lib/types/collections.js
@@ -16,6 +16,7 @@ const Collection = new GraphQLInterfaceType({
 	fields: {
 		title: { type: GraphQLString },
 		url: { type: GraphQLString },
+		layoutHint: { type: GraphQLString },
 		items: {
 			type: new GraphQLList(Content),
 			args: {
@@ -51,6 +52,10 @@ const Page = new GraphQLObjectType({
 		title: {
 			type: GraphQLString
 		},
+		layoutHint: {
+			type: GraphQLString,
+			resolve: ([page, list]) => list ? list.layoutHint : null
+		},
 		items: {
 			type: new GraphQLList(Content),
 			description: 'Content items of the page',
@@ -60,8 +65,12 @@ const Page = new GraphQLObjectType({
 				genres: { type: new GraphQLList(GraphQLString) },
 				type: { type: ContentType }
 			},
-			resolve: (page, {from, limit, genres, type}, {rootValue: {flags}}) => {
+			resolve: ([page, list], {from, limit, genres, type}, {rootValue: {flags}}) => {
 				if(!page.items || page.items.length < 1) { return []; }
+
+				if(list && list.layoutHint === 'standaloneimage' && list.items && list.items.length && list.items[0].id) {
+					page.items.unshift(list.items[0].id.replace(/http:\/\/api\.ft\.com\/things?\//, ''));
+				}
 				return backend(flags).capi.content(page.items, {from, limit, genres, type});
 			}
 		}
@@ -79,6 +88,10 @@ const ContentByConcept = new GraphQLObjectType({
 		url: {
 			type: GraphQLString,
 			resolve: () => (null)
+		},
+		layoutHint: {
+			type: GraphQLString,
+			resolve: () => null
 		},
 		items: {
 			type: new GraphQLList(Content),
@@ -110,6 +123,10 @@ const List = new GraphQLObjectType({
 		url: {
 			type: GraphQLString,
 			resolve: () => (null)
+		},
+		layoutHint: {
+			type: GraphQLString,
+			resolve: list => list.layoutHint
 		},
 		items: {
 			type: new GraphQLList(Content),

--- a/test/server/lib/capi.test.js
+++ b/test/server/lib/capi.test.js
@@ -120,7 +120,7 @@ describe('CAPI backend', () => {
 		});
 
 		afterEach(() => {
-			stubAPI.reset();
+			stubAPI.restore();
 			Object.keys(cache.contentCache).forEach(key => cache.clear(key));
 		});
 		it('fetches list', () => {

--- a/test/server/lib/top-stories.test.js
+++ b/test/server/lib/top-stories.test.js
@@ -35,7 +35,7 @@ describe('Top Stories', () => {
 				},
 				{
 					name: 'elastic-search',
-					matcher: '^https://search-next-search-edgfdq5nx64rl5widrjtd65epq.eu-west-1.es.amazonaws.com',
+					matcher: '^https://search-next-search-',
 					response: (url, opts) => {
 						const docs = JSON.parse(opts.body).ids.map(id => ({ found: true, _source: { id } }))
 						return { docs: docs };
@@ -185,7 +185,7 @@ describe('Top Stories', () => {
 				},
 				{
 					name: 'elastic-search',
-					matcher: '^https://search-next-search-edgfdq5nx64rl5widrjtd65epq.eu-west-1.es.amazonaws.com',
+					matcher: '^https://search-next-search-',
 					response: (url, opts) => {
 						const docs = JSON.parse(opts.body).ids.map(id => ({ found: true, _source: { id } }))
 						return { docs: docs };

--- a/test/server/lib/top-stories.test.js
+++ b/test/server/lib/top-stories.test.js
@@ -1,0 +1,220 @@
+import realFetch from 'isomorphic-fetch';
+import fetchMock from 'fetch-mock';
+import sinon from 'sinon';
+import chai from 'chai';
+
+const should = chai.should();
+
+import graphqlClient from '../../../server/lib/graphql';
+
+
+describe('Top Stories', () => {
+
+	before(() => {
+		const clock = sinon.useFakeTimers();
+		clock.tick(1000 * 60 * 60 * 60 * 24);
+		global.fetch = realFetch;
+
+		fetchMock.mock({
+			routes: [
+				{
+					name: 'capi-page-uk',
+					matcher: '^http://api.ft.com/site/v1/pages/4c499f12-4e94-11de-8d4c-00144feabdc0/main-content',
+					response: {
+						page: { title: 'title' },
+						pageItems: [
+							{id: 'standard-page-item-1'},
+							{id: 'standard-page-item-2'}
+						]
+					}
+				},
+				{
+					name: 'capi-list-uk',
+					matcher: '^http://api.ft.com/lists/520ddb76-e43d-11e4-9e89-00144feab7de',
+					response: 500
+				},
+				{
+					name: 'elastic-search',
+					matcher: '^https://search-next-search-edgfdq5nx64rl5widrjtd65epq.eu-west-1.es.amazonaws.com',
+					response: (url, opts) => {
+						const docs = JSON.parse(opts.body).ids.map(id => ({ found: true, _source: { id } }))
+						return { docs: docs };
+					}
+				}
+			],
+			greed: 'good'
+		});
+	});
+
+
+
+	it('still works when lists API is down', () => {
+
+		return graphqlClient({ frontPageMultipleLayouts: true })
+			.fetch(`
+				query TopStories {
+					top(region: UK) {
+						layoutHint
+						items(limit: 1) {
+							type: __typename
+							contentType
+							id
+							title
+							lastPublished
+						}
+					}
+				}
+			`)
+			.then(it => {
+				it.top.should.exist;
+				it.top.items.length.should.equal(1);
+				it.top.items[0].id.should.equal('standard-page-item-1');
+				should.equal(it.top.layoutHint, null);
+			});
+	});
+
+
+	it('Returns only the page when frontPageMultipleLayouts flag is off', () => {
+
+		fetchMock.reMock({
+			routes: [
+				{
+					name: 'capi-list-uk',
+					matcher: '^http://api.ft.com/lists/520ddb76-e43d-11e4-9e89-00144feab7de',
+					response: {
+						layoutHint: 'standard',
+						items: [
+							{id: 'standard-list-item-1'},
+							{id: 'standard-list-item-2'}
+						]
+					}
+				}
+			]
+		});
+
+		return graphqlClient({ frontPageMultipleLayouts: false })
+			.fetch(`
+				query TopStories {
+					top(region: UK) {
+						layoutHint
+						items(limit: 1) {
+							type: __typename
+							contentType
+							id
+							title
+							lastPublished
+						}
+					}
+				}
+			`)
+			.then(it => {
+				it.top.should.exist;
+				it.top.items.length.should.equal(1);
+				it.top.items[0].id.should.equal('standard-page-item-1');
+				should.equal(it.top.layoutHint, null);
+			});
+	});
+
+	it('fetches page with layouthint from list and content from page', () => {
+
+		fetchMock.reMock({
+			routes: [
+				{
+					name: 'capi-list-uk',
+					matcher: '^http://api.ft.com/lists/520ddb76-e43d-11e4-9e89-00144feab7de',
+					response: {
+						layoutHint: 'standard',
+						items: [
+							{id: 'http://api.ft.com/things/standard-list-item-1'},
+							{id: 'http://api.ft.com/things/standard-list-item-2'}
+						]
+					}
+				}
+			]
+		});
+
+		return graphqlClient({ frontPageMultipleLayouts: true })
+			.fetch(`
+				query TopStories {
+					top(region: UK) {
+						layoutHint
+						items(limit: 1) {
+							type: __typename
+							contentType
+							id
+							title
+							lastPublished
+						}
+					}
+				}
+			`)
+			.then(it => {
+				it.top.should.exist;
+				it.top.items.length.should.equal(1);
+				it.top.items[0].id.should.equal('standard-page-item-1');
+				it.top.layoutHint.should.equal('standard');
+			});
+	});
+
+
+	it('if the layout is a picture story, brings in the top story from the list', () => {
+
+		fetchMock.reMock({
+			routes: [
+				{
+					name: 'capi-page-us',
+					matcher: '^http://api.ft.com/site/v1/pages/b0ed86f4-4e94-11de-8d4c-00144feabdc0/main-content',
+					response: {
+						page: { title: 'title' },
+						pageItems: [
+							{id: 'standard-page-item-1'},
+							{id: 'standard-page-item-2'}
+						]
+					}
+				},
+				{
+					name: 'capi-list-us',
+					matcher: '^http://api.ft.com/lists/b0d8e4fe-10ff-11e5-8413-00144feabdc0',
+					response: {
+						layoutHint: 'standaloneimage',
+						items: [
+							{id: 'http://api.ft.com/things/standard-list-item-1'},
+							{id: 'http://api.ft.com/things/standard-list-item-2'}
+						]
+					}
+				},
+				{
+					name: 'elastic-search',
+					matcher: '^https://search-next-search-edgfdq5nx64rl5widrjtd65epq.eu-west-1.es.amazonaws.com',
+					response: (url, opts) => {
+						const docs = JSON.parse(opts.body).ids.map(id => ({ found: true, _source: { id } }))
+						return { docs: docs };
+				}
+			}
+			]
+		});
+
+		return graphqlClient({ frontPageMultipleLayouts: true })
+			.fetch(`
+				query TopStories {
+					top(region: US) {
+						layoutHint
+						items(limit: 2) {
+							type: __typename
+							contentType
+							id
+							title
+							lastPublished
+						}
+					}
+				}
+			`)
+			.then(it => {
+				it.top.should.exist;
+				it.top.items.length.should.equal(2);
+				it.top.items[0].id.should.equal('standard-list-item-1');
+				it.top.items[1].id.should.equal('standard-page-item-1');
+				it.top.layoutHint.should.equal('standaloneimage');
+			});
+	});
+});

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -2,6 +2,9 @@ const query = `
 	query GraphQLSmoke {
 		popularTopics {
 			name
+			items(limit: 1) {
+				name
+			}
 		}
 		top(region: UK) {
 			layoutHint
@@ -30,6 +33,10 @@ const query = `
 			url
 			items {
 				title
+				branding {
+					headshot
+					taxonomy
+		    }
 			}
 		}
 		lifestyle {

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -4,6 +4,7 @@ const query = `
 			name
 		}
 		top(region: UK) {
+			layoutHint
 			lead: items(limit: 1, type: Article) {
 				title
 			}


### PR DESCRIPTION
/cc @ironsidevsquincy @matthew-andrews @andygout 

Replaces https://github.com/Financial-Times/next-graphql-api/pull/67

* Top stories can get layoutHint from lists API
* Behind frontPageMultipleLayouts flag
* Items return from old CAPI Page
* If flag is off, or list API down, `layoutHint` returns null and items still return from Page
* IF layoutHInt is `standaloneimage`, the first item returned will be taken from the list (and appended on to the page) - as picture stories aren't returned in the Pages API.