### PR TITLE
Return top stories page and list separately

### DIFF
--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -37,7 +37,6 @@ const queryType = new GraphQLObjectType({
 			},
 			resolve: (root, {region}, {rootValue: {flags}}) => {
 				let uuid = sources[`${region}TopList`].uuid;
-				console.log('uuid', uuid);
 				return backend(flags).capi.list(uuid);
 			}
 		},

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -8,7 +8,7 @@ import {
 } from 'graphql';
 
 import { Region } from './types/basic';
-import { Page, List, ContentByConcept, CombinedPageAndList } from './types/collections';
+import { Page, List, ContentByConcept } from './types/collections';
 import { Content, Video, Concept } from './types/content';
 import { ContentType } from './types/basic';
 import User from './types/user';
@@ -21,15 +21,24 @@ const queryType = new GraphQLObjectType({
 	description: 'FT content API',
 	fields: {
 		top: {
-			type: CombinedPageAndList,
+			type: Page,
 			args: {
 				region: { type: new GraphQLNonNull(Region) }
 			},
 			resolve: (root, {region}, {rootValue: {flags}}) => {
 				const uuid = sources[`${region}Top`].uuid;
-				const listUuid = sources[`${region}TopList`].uuid;
-				const listFetch = flags.frontPageMultipleLayouts ? backend(flags).capi.list(listUuid).catch(() => {}) : Promise.resolve({});
-				return Promise.all([backend(flags).capi.page(uuid), listFetch]);
+				return backend(flags).capi.page(uuid);
+			}
+		},
+		topStoriesList: {
+			type: List,
+			args: {
+				region: { type: new GraphQLNonNull(Region) }
+			},
+			resolve: (root, {region}, {rootValue: {flags}}) => {
+				let uuid = sources[`${region}TopList`].uuid;
+				console.log('uuid', uuid);
+				return backend(flags).capi.list(uuid);
 			}
 		},
 		fastFT: {

--- a/server/lib/types/collections.js
+++ b/server/lib/types/collections.js
@@ -10,44 +10,6 @@ import { ContentType } from './basic';
 import backend from '../backend-adapters/index';
 
 
-const CombinedPageAndList = new GraphQLObjectType({
-	name: 'CombinedPageAndList',
-	description: 'Page of content with metadata from List',
-	fields: {
-		url: {
-			type: GraphQLString,
-			resolve: (it) => {
-				return (it.sectionId ? `/stream/sectionsId/${it.sectionId}` : null);
-			}
-		},
-		title: {
-			type: GraphQLString
-		},
-		layoutHint: {
-			type: GraphQLString,
-			resolve: ([, list]) => list ? list.layoutHint : null
-		},
-		items: {
-			type: new GraphQLList(Content),
-			description: 'Content items of the page',
-			args: {
-				from: { type: GraphQLInt },
-				limit: { type: GraphQLInt },
-				genres: { type: new GraphQLList(GraphQLString) },
-				type: { type: ContentType }
-			},
-			resolve: ([page, list], {from, limit, genres, type}, {rootValue: {flags}}) => {
-				if(!page.items || page.items.length < 1) { return []; }
-				//Picture stories don't come through the page API, so need to take the picture story from the list
-				if(list && list.layoutHint === 'standaloneimage' && list.items && list.items.length && list.items[0].id) {
-					page.items.unshift(list.items[0].id.replace(/http:\/\/api\.ft\.com\/things?\//, ''));
-				}
-				return backend(flags).capi.content(page.items, {from, limit, genres, type});
-			}
-		}
-	}
-});
-
 const Page = new GraphQLObjectType({
 	name: 'Page',
 	description: 'Page of content',
@@ -141,7 +103,7 @@ const List = new GraphQLObjectType({
 				type: { type: ContentType }
 			},
 			resolve: (result, args, {rootValue: {flags}}) => {
-
+				console.log('result', result);
 				if(!result.items || result.items.length < 1) { return []; }
 
 				return backend(flags).capi.content(result.items.map(result => result.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args);
@@ -152,7 +114,6 @@ const List = new GraphQLObjectType({
 
 export {
 	Page,
-	CombinedPageAndList,
 	ContentByConcept,
 	List
 };

--- a/server/lib/types/collections.js
+++ b/server/lib/types/collections.js
@@ -103,7 +103,6 @@ const List = new GraphQLObjectType({
 				type: { type: ContentType }
 			},
 			resolve: (result, args, {rootValue: {flags}}) => {
-				console.log('result', result);
 				if(!result.items || result.items.length < 1) { return []; }
 
 				return backend(flags).capi.content(result.items.map(result => result.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args);

--- a/test/server/lib/top-stories.test.js
+++ b/test/server/lib/top-stories.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import chai from 'chai';
 
 const expect = chai.expect;
-const should = chai.should();
+chai.should();
 
 import graphqlClient from '../../../server/lib/graphql';
 

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -18,6 +18,12 @@ const query = `
 				title
 			}
 		}
+		topStoriesList(region: UK) {
+			layoutHint
+			items(limit: 10) {
+				title
+			}
+		}
 		fastFT {
 			items(limit: 5) {
 				title


### PR DESCRIPTION
/cc @ironsidevsquincy 

As discussed, separates out the page from the list, meaning we can keep all flag/picture story hacks within the front page.