### PR TITLE
Add most popular topic endpoints from myFT API backend

### DIFF
--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -45,7 +45,6 @@ class CAPI {
 				}
 			}
 		};
-
 		return this.cache.cached(`${this.type}.search.${termName}:${termValue}`, ttl, () => {
 			return ApiClient.search(searchOpts);
 		})
@@ -66,6 +65,16 @@ class CAPI {
 	list(uuid, ttl = 50) {
 		return this.cache.cached(`${this.type}.lists.${uuid}`, ttl, () => {
 			return ApiClient.lists({ uuid: uuid })
+		});
+	}
+
+	things(uuids, ttl = 50) {
+		const cacheKey = `${this.type}.things.${Array.isArray(uuids) ? uuids.join('_') : uuids}`;
+		return this.cache.cached(cacheKey, ttl, () => {
+			return ApiClient.things({
+				identifierValues: uuids,
+				authority: 'http://api.ft.com/system/FT-TME'
+			});
 		});
 	}
 }

--- a/server/lib/backend-adapters/myft.js
+++ b/server/lib/backend-adapters/myft.js
@@ -36,6 +36,19 @@ class Myft {
 					.slice(0, limit)
 			);
 	}
+
+	getMostReadTopics({ limit = 10 }) {
+		return myftClient.fetchJson('GET', 'recommendation/most-read/concept', { limit })
+				.then(results => results.items
+					.filter(concept => concept));
+	}
+
+	getMostFollowedTopics({ limit = 10 }) {
+		return myftClient.fetchJson('GET', 'recommendation/most-followed/concept', { limit })
+				.then(results => results.items
+					.filter(concept => concept));
+	}
+
 }
 
 export default Myft;

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -109,6 +109,26 @@ const queryType = new GraphQLObjectType({
 				return backend(flags).popularApi.topics({from, limit})
 			}
 		},
+		popularReadTopicsFromMyFtApi: {
+			type: new GraphQLList(Concept),
+			args: {
+				limit: { type: GraphQLInt }
+			},
+			resolve: (root, {limit}, {rootValue: {flags}}) => {
+				return backend(flags).myft.getMostReadTopics({limit})
+						.then(items => backend(flags).capi.things(items.map(t => t.uuid)).then(c => c.items));
+			}
+		},
+		popularFollowedTopicsFromMyFtApi: {
+			type: new GraphQLList(Concept),
+			args: {
+				limit: { type: GraphQLInt }
+			},
+			resolve: (root, {limit}, {rootValue: {flags}}) => {
+				return backend(flags).myft.getMostFollowedTopics({limit})
+						.then(items => backend(flags).capi.things(items.map(t => t.uuid)).then(c => c.items));
+			}
+		},
 		popularArticles: {
 			type: new GraphQLList(Content),
 			args: {


### PR DESCRIPTION
Add two new graph endpoints which return concepts and content. 

- `popularReadTopicsFromMyFtApi` most read concepts within the myFT eco-system
- `popularFollowedTopicsFromMyFtApi ` most followed concepts within the myFT eco-system

In order for these to work I've had to add a `topics` method to the CAPI backend which accepts an array of concept ids and hydrates them to full concept terms via the ES interface. This requires a new version of the client with the corresponding work in [#66](https://github.com/Financial-Times/next-ft-api-client/pull/66)

/cc @ironsidevsquincy 