### PR TITLE
Add new popularTopicsFromHui endpoint

### DIFF
--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -68,11 +68,12 @@ class CAPI {
 		});
 	}
 
-	things(uuids, ttl = 50) {
-		const cacheKey = `${this.type}.things.${Array.isArray(uuids) ? uuids.join('_') : uuids}`;
+	things(uuids, type = 'idV1', ttl = 50) {
+		const cacheKey = `${this.type}.things.${type}.${Array.isArray(uuids) ? uuids.join('_') : uuids}`;
 		return this.cache.cached(cacheKey, ttl, () => {
 			return ApiClient.things({
 				identifierValues: uuids,
+				identifierType: type,
 				authority: 'http://api.ft.com/system/FT-TME'
 			});
 		});

--- a/server/lib/backend-adapters/hui.js
+++ b/server/lib/backend-adapters/hui.js
@@ -8,8 +8,15 @@ class Hui {
 	}
 
 	content({industry, position, sector, country, period='last-1-week', from, limit}, ttl = 50) {
-		return this.cache.cached(`${this.type}.${industry}.${position}.${sector}.${country}.${period}`, ttl, () => {
-			return ApiClient.hui({industry, position, sector, country, period})
+		return this.cache.cached(`${this.type}.content.${industry}.${position}.${sector}.${country}.${period}`, ttl, () => {
+			return ApiClient.hui({model: 'content', industry, position, sector, country, period})
+				.then(articles => sliceList(articles, {from, limit}));
+		});
+	}
+
+	topics({industry, position, sector, country, period='last-1-week', from, limit}, ttl = 50) {
+		return this.cache.cached(`${this.type}.topics.${industry}.${position}.${sector}.${country}.${period}`, ttl, () => {
+			return ApiClient.hui({model: 'annotations', industry, position, sector, country, period})
 				.then(articles => sliceList(articles, {from, limit}));
 		});
 	}

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -188,6 +188,46 @@ const queryType = new GraphQLObjectType({
 					.then(articles => be.capi.content(articles, args));
 			}
 		},
+		popularTopicsFromHui: {
+			type: new GraphQLList(Concept),
+			args: {
+				industry: {
+					type: GraphQLString
+				},
+				position: {
+					type: GraphQLString
+				},
+				sector: {
+					type: GraphQLString
+				},
+				country: {
+					type: GraphQLString
+				},
+				period: {
+					type: GraphQLString
+				},
+				from: {
+					type: GraphQLInt
+				},
+				limit: {
+					type: GraphQLInt
+				},
+				genres: {
+					type: new GraphQLList(GraphQLString)
+				},
+				type: {
+					type: ContentType
+				}
+			},
+			resolve: (root, args, {rootValue: {flags}}) => {
+				return backend(flags).hui.topics(args)
+						.then(items => {
+							return backend(flags).capi
+									.things(items, 'prefLabel')
+									.then(c => c.items);
+						});
+			}
+		},
 		user: {
 			type: User,
 			args: {


### PR DESCRIPTION
The existing HUI endpoint returns `Content` but the myFT explore page is only concerned about `Concepts`, fortunately the HUI API allows you to define which type you are interested in. Therefore I have added a new endpoint to fetch this data. We also then have to search for the real concept's as HUI sadly only returns strings.

/cc @ironsidevsquincy 