### PR TITLE
Add new TodaysTopics endpoint

### DIFF
--- a/server/lib/backend-adapters/index.js
+++ b/server/lib/backend-adapters/index.js
@@ -9,6 +9,7 @@ import MockLiveblog from './mock-liveblog';
 import Video from './video';
 import PopularAPI from './popular-api';
 import Myft from './myft';
+import TodaysTopics from './todays-topics';
 
 import Cache from '../cache';
 
@@ -23,6 +24,7 @@ const mockLiveblog = new MockLiveblog(liveblog);
 const myft = new Myft(memCache);
 const popularApi = new PopularAPI(memCache);
 const video = new Video(memCache);
+const todaysTopics = new TodaysTopics(memCache);
 
 export default (flags = {}) => ({
 	capi: flags.mockFrontPage ? mockCapi : capi,
@@ -31,6 +33,7 @@ export default (flags = {}) => ({
 	liveblog: flags.mockFrontPage ? mockLiveblog : liveblog,
 	myft,
 	popularApi,
-	video
+	video,
+	todaysTopics
 });
 

--- a/server/lib/backend-adapters/todays-topics.js
+++ b/server/lib/backend-adapters/todays-topics.js
@@ -36,11 +36,7 @@ class TodaysTopics {
 					return res.find(i => i.idV1 === item.idV1) ? res : res.concat(item);
 				}, []);
 				//Sort by frequency
-				const result = uniq.sort((a, b) => {
-					if (countById[a.idV1] > countById[b.idV1]) return -1;
-					if (countById[a.idV1] < countById[b.idV1]) return 1;
-					return 0;
-				});
+				const result = uniq.sort((a, b) => countById[b.idV1] - countById[a.idV1]);
 
 				return result.slice(0, limit);
 			});

--- a/server/lib/backend-adapters/todays-topics.js
+++ b/server/lib/backend-adapters/todays-topics.js
@@ -17,7 +17,6 @@ class TodaysTopics {
 	getTopics({region, from, limit, genres, type}, flags = {}, ttl = 10) {
 		const cacheKey = `${this.type}.region.${region}`;
 		return this.cache.cached(cacheKey, ttl, () => {
-			const uuid = sources[`${region}Top`].uuid;
 			const be = backend(flags);
 			const args = { from, limit, genres, type };
 			return Promise.all([

--- a/server/lib/backend-adapters/todays-topics.js
+++ b/server/lib/backend-adapters/todays-topics.js
@@ -1,0 +1,52 @@
+'use strict';
+import sources from '../../config/sources';
+import backend from '.';
+
+function getPrimaryTag(metadata) {
+	const primarySection = metadata.find(tag => tag.primary === 'section');
+	const primaryTheme = metadata.find(tag => tag.primary === 'theme');
+	return primaryTheme || primarySection || null;
+}
+
+class TodaysTopics {
+	constructor(cache) {
+		this.type = 'todays-topics';
+		this.cache = cache;
+	}
+
+	getTopics({region, from, limit, genres, type}, flags = {}, ttl = 10) {
+		const cacheKey = `${this.type}.region.${region}`;
+		return this.cache.cached(cacheKey, ttl, () => {
+			const uuid = sources[`${region}Top`].uuid;
+			const be = backend(flags);
+			const args = { from, limit, genres, type };
+			return Promise.all([
+				be.capi.page(sources[`${region}Top`].uuid).then(p => be.capi.content(p.items, args)).then(c => c.map(c => getPrimaryTag(c.metadata))),
+				be.capi.page(sources.opinion.uuid, sources.opinion.sectionsId).then(p => be.capi.content(p.items, args)).then(c => c.map(c => getPrimaryTag(c.metadata))),
+				be.capi.list(sources.editorsPicks.uuid).then(r => be.capi.content(r.items.map(i => i.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args)).then(c => c.map(c => getPrimaryTag(c.metadata)))
+			]).then((data) => {
+				//Flatten results
+				const tags = data.reduce((res, item) => res.concat(item), []);
+				//Group by frequency of tag
+				const countById = tags.reduce((res, item) => {
+					res[item.idV1] = res[item.idV1] ? ++res[item.idV1] : 1;
+					return res;
+				}, {});
+				//Dedupe
+				const uniq = tags.reduce((res, item) => {
+					return res.find(i => i.idV1 === item.idV1) ? res : res.concat(item);
+				}, []);
+				//Sort by frequency
+				const result = uniq.sort((a, b) => {
+					if (countById[a.idV1] > countById[b.idV1]) return -1;
+					if (countById[a.idV1] < countById[b.idV1]) return 1;
+					return 0;
+				});
+
+				return result.slice(0, limit);
+			});
+		});
+	}
+}
+
+export default TodaysTopics;

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -109,23 +109,7 @@ const queryType = new GraphQLObjectType({
 				type: { type: ContentType }
 			},
 			resolve: (root, {region, from, limit, genres, type}, {rootValue: {flags}}) => {
-				const uuid = sources[`${region}Top`].uuid;
-				const be = backend(flags);
-				const args = { from, limit, genres, type };
-				function getPrimaryTag(metadata) {
-					const primarySection = metadata.find(tag => tag.primary === 'section');
-					const primaryTheme = metadata.find(tag => tag.primary === 'theme');
-					return primaryTheme || primarySection || null;
-				}
-				return Promise.all([
-					be.capi.page(sources[`${region}Top`].uuid).then(p => be.capi.content(p.items, args)).then(c => c.map(c => getPrimaryTag(c.metadata))),
-					be.capi.page(sources.opinion.uuid, sources.opinion.sectionsId).then(p => be.capi.content(p.items, args)).then(c => c.map(c => getPrimaryTag(c.metadata))),
-					be.capi.list(sources.editorsPicks.uuid).then(r => be.capi.content(r.items.map(i => i.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args)).then(c => c.map(c => getPrimaryTag(c.metadata)))
-				]).then((data) => {
-					const tags = data.reduce((res, next) => res.concat(next), []);
-
-					return tags;
-				});
+				return backend(flags).todaysTopics.getTopics({region, from, limit, genres, type}, flags);
 			}
 		},
 		popularTopics: {


### PR DESCRIPTION
Another experimental recommendation endpoint for myFT. We wish to get a view of the current most written about/FT view of topics. To achieve this we are taking the most frequent topics from the homepage top-stories, opinion and editors picks lists and reducing them down to a single list.

It looks scary and is a lot of requests, but all of which are heavily cached already.

/cc @ironsidevsquincy 