### PR TITLE
Postpone point at which hui topic results are limited

### DIFF
--- a/server/lib/backend-adapters/hui.js
+++ b/server/lib/backend-adapters/hui.js
@@ -14,10 +14,9 @@ class Hui {
 		});
 	}
 
-	topics({industry, position, sector, country, period='last-1-week', from, limit}, ttl = 50) {
+	topics({industry, position, sector, country, period='last-1-week'}, ttl = 50) {
 		return this.cache.cached(`${this.type}.topics.${industry}.${position}.${sector}.${country}.${period}`, ttl, () => {
-			return ApiClient.hui({model: 'annotations', industry, position, sector, country, period})
-				.then(articles => sliceList(articles, {from, limit}));
+			return ApiClient.hui({model: 'annotations', industry, position, sector, country, period});
 		});
 	}
 

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -232,12 +232,15 @@ const queryType = new GraphQLObjectType({
 					type: ContentType
 				}
 			},
-			resolve: (root, args, {rootValue: {flags}}) => {
-				return backend(flags).hui.topics(args)
+			resolve: (root, { industry, position, sector, country, period, from, limit, genres, type}, {rootValue: {flags}}) => {
+				return backend(flags)
+						.hui.topics({industry, position, sector, country, period})
 						.then(items => {
 							return backend(flags).capi
 									.things(items, 'prefLabel')
-									.then(c => c.items);
+									.then(c => c.items
+												.filter(t => t)
+												.slice(0, limit));
 						});
 			}
 		},


### PR DESCRIPTION
Currently we limit the results from HUI before looking them up in CAPI. The CAPI lookup has potential to fail as its just string searching the `prefLabel` and not direct `id` lookups. Due to this, we are seeing empty results coming back. Therefore to increase the probability of hitting your requested limit, I am now only limiting at the last point once the concepts have be hydrated from CAPI.

/cc @keirog @ironsidevsquincy 