### PR TITLE
Fix topic caching

### DIFF
--- a/server/lib/backend-adapters/todays-topics.js
+++ b/server/lib/backend-adapters/todays-topics.js
@@ -38,7 +38,7 @@ class TodaysTopics {
 				//Sort by frequency
 				const result = uniq.sort((a, b) => countById[b.idV1] - countById[a.idV1]);
 
-				return result.slice(0, limit);
+				return result;
 			});
 		});
 	}

--- a/server/lib/backend-adapters/todays-topics.js
+++ b/server/lib/backend-adapters/todays-topics.js
@@ -14,7 +14,7 @@ class TodaysTopics {
 		this.cache = cache;
 	}
 
-	getTopics({region, from, limit, genres, type}, flags = {}, ttl = 10) {
+	getTopics({region, from, limit, genres, type}, flags = {}, ttl = 60 * 10) {
 		const cacheKey = `${this.type}.region.${region}`;
 		return this.cache.cached(cacheKey, ttl, () => {
 			const be = backend(flags);

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -109,7 +109,10 @@ const queryType = new GraphQLObjectType({
 				type: { type: ContentType }
 			},
 			resolve: (root, {region, from, limit, genres, type}, {rootValue: {flags}}) => {
-				return backend(flags).todaysTopics.getTopics({region, from, limit, genres, type}, flags);
+				return backend(flags)
+						.todaysTopics
+						.getTopics({region, from, limit, genres, type}, flags)
+						.then(topics => topics.slice(0, limit));
 			}
 		},
 		popularTopics: {
@@ -119,7 +122,7 @@ const queryType = new GraphQLObjectType({
 				limit: { type: GraphQLInt }
 			},
 			resolve: (root, {from, limit}, {rootValue: {flags}}) => {
-				return backend(flags).popularApi.topics({from, limit})
+				return backend(flags).popularApi.topics({from, limit});
 			}
 		},
 		popularReadTopicsFromMyFtApi: {


### PR DESCRIPTION
Originally I was limiting the result set from `todaysTopics` inside the backend adaptor, that was causing the potential for a consumer to get a different cached limit to the one they had requested. Moving to the schema resolver solves this. I've also up'ed the cache time of this endpoint to ten minutes.

/cc @ironsidevsquincy @keirog 