### PR TITLE
Diagnose double session logging

### DIFF
--- a/server/lib/user-auth.js
+++ b/server/lib/user-auth.js
@@ -1,4 +1,5 @@
 import { json as fetchresJson } from 'fetchres';
+import logger from '@financial-times/n-logger';
 
 import { HttpError } from './errors';
 
@@ -31,6 +32,7 @@ export default (req, uuid) => {
 				return response.uuid;
 			})
 			.catch(err => {
+				logger.warn('Testing session endpoint failure double logging', { date: Date.now() });
 				throw new HttpError(`Session endpoint responded with error server_error_name=${err.name} server_error_message=${err.message} ft_session=${req.cookies.FTSession}`, 500);
 			});
 	} else {


### PR DESCRIPTION
Trying to work out why session errors are being logged twice 

https://splunk.internal.ft.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%22%2Fvar%2Flog%2Fapps%2Fheroku%2Fft-next-graphql-api.log%22%20Session%20endpoint&display.page.search.mode=smart&earliest=1458061200&latest=1458064800&display.events.fields=%5B%22app%22%2C%22url%22%2C%22error_message%22%2C%22error_name%22%2C%22level%22%2C%22message%22%5D&display.general.type=events&display.visualizations.charting.chart=line&display.page.search.tab=events&sid=1458063084.138100.splunk-prod-head-03