### PR TITLE
Concepts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "graphiql": "^0.5.0",
     "graphql": "^0.4.2",
     "http-status-codes": "^1.0.6",
+    "moment": "^2.12.0",
     "n-health": "^1.2.2",
     "next-ft-api-client": "^3.15.0",
     "next-myft-client": "^6.1.5",

--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -74,15 +74,22 @@ export default class {
 	}
 
 	search (termName, termValue, opts, ttl = 60 * 10) {
-		let optsCacheKey = `${opts.since ? `:since_${opts.since}` : ''}${opts.count ? `:since_${opts.count}` : ''}`;
-		return this.cache.cached(`${this.type}.search.${termName}:${termValue}${optsCacheKey}`, ttl, () =>
+
+		const optsCacheKey = `${opts.since ? `:since_${opts.since}` : ''}${opts.count ? `:since_${opts.count}` : ''}`;
+		const cacheKey = `${this.type}.search.${termName}:${termValue}${optsCacheKey}`;
+
+		return this.cache.cached(cacheKey, ttl, () =>
 				ApiClient.search(getSearchOpts(termName, termValue, opts))
-		).then(filterContent(opts, resolveContentType));
+		)
+			.then(filterContent(opts, resolveContentType));
 	}
 
 	searchCount (termName, termValue, opts, ttl = 60 * 10) {
-		let optsCacheKey = `${opts.since ? `:since_${opts.since}` : ''}${opts.count ? `:since_${opts.count}` : ''}`;
-		return this.cache.cached(`${this.type}.searchCount.${termName}:${termValue}${optsCacheKey}`, ttl, () =>
+
+		const optsCacheKey = `${opts.since ? `:since_${opts.since}` : ''}${opts.count ? `:since_${opts.count}` : ''}`;
+		const cacheKey = `${this.type}.searchCount.${termName}:${termValue}${optsCacheKey}`;
+
+		return this.cache.cached(cacheKey, ttl, () =>
 				ApiClient.search(getSearchOpts(termName, termValue, opts))
 		)
 			.then(filterContent(opts, resolveContentType))

--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -77,6 +77,8 @@ export default class {
 		return this._search('search', termName, termValue, opts, ttl);
 	}
 
+	// searchCount is separate from search so that we can look a long way back just for the sake of counting articles
+	// and cache the count only, avoiding caching loads of unused content
 	searchCount (termName, termValue, opts, ttl = 60 * 10) {
 		return this._search('searchCount', termName, termValue, opts, ttl, (items => items.length));
 	}

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -271,6 +271,16 @@ const queryType = new GraphQLObjectType({
 				}
 			},
 			resolve: (root, { uuid }, { rootValue: { req }}) => userAuth(req, uuid).then(uuid => ({ uuid }))
+		},
+		concepts: {
+			type: new GraphQLList(Concept),
+			args: {
+				ids: {
+					type: new GraphQLList(GraphQLString)
+				}
+			},
+			resolve: (root, { ids }, { rootValue: { flags, backend = backendReal }}) =>
+				backend(flags).capi.things(ids).then(c => c.items)
 		}
 	}
 });

--- a/server/lib/types/content.js
+++ b/server/lib/types/content.js
@@ -267,13 +267,22 @@ const Concept = new GraphQLObjectType({
 		},
 		articleCount: {
 			type: GraphQLInt,
-			description: 'Number of articles published with this concept since the given date (defaults to 1 week, max 100 results)',
+			description: `
+				Approximate number of articles published with this concept since the given date, up to a
+				maximum value of count (default date is 1 week, default count is 100)`,
 			args: {
-				since: { type: GraphQLString }
+				since: {
+					type: GraphQLString,
+					defaultValue: moment().subtract(7, 'days').format('YYYY-MM-DD')
+				},
+				count: {
+					type: GraphQLInt,
+					defaultValue: 100
+				}
 			},
-			resolve: (concept, { since }, { rootValue: { flags, backend = backendReal }}) => {
+			resolve: (concept, { since, count }, { rootValue: { flags, backend = backendReal }}) => {
 				const id = concept.id || concept.idV1 || concept.uuid;
-				return backend(flags).capi.searchCount('metadata.idV1', id, { count: 100, since: since || moment().subtract(7, 'days').format()});
+				return backend(flags).capi.searchCount('metadata.idV1', id, { count, since});
 			}
 		},
 		items: {

--- a/server/lib/types/content.js
+++ b/server/lib/types/content.js
@@ -5,6 +5,7 @@ import articleBranding from 'ft-n-article-branding';
 import capifyMetadata from '../helpers/capify-metadata';
 import backendReal from '../backend-adapters/index';
 import { LiveBlogStatus, ContentType } from './basic';
+import moment from 'moment';
 
 const podcastIdV1 = 'NjI2MWZlMTEtMTE2NS00ZmI0LWFkMzMtNDhiYjA3YjcxYzIy-U2VjdGlvbnM=';
 
@@ -263,6 +264,17 @@ const Concept = new GraphQLObjectType({
 		},
 		headshot: {
 			type: GraphQLString
+		},
+		articleCount: {
+			type: GraphQLInt,
+			description: 'Number of articles published with this concept since the given date (defaults to 1 week, max 100 results)',
+			args: {
+				since: { type: GraphQLString }
+			},
+			resolve: (concept, { since }, { rootValue: { flags, backend = backendReal }}) => {
+				const id = concept.id || concept.idV1 || concept.uuid;
+				return backend(flags).capi.searchCount('metadata.idV1', id, { count: 100, since: since || moment().subtract(7, 'days').format()});
+			}
 		},
 		items: {
 			type: new GraphQLList(Content),

--- a/server/lib/types/content.js
+++ b/server/lib/types/content.js
@@ -271,11 +271,13 @@ const Concept = new GraphQLObjectType({
 				from: { type: GraphQLInt },
 				limit: { type: GraphQLInt },
 				genres: { type: new GraphQLList(GraphQLString) },
-				type: { type: ContentType }
+				type: { type: ContentType },
+				count: { type: GraphQLInt },
+				since: { type: GraphQLString }
 			},
-			resolve: (concept, { from, limit, genres, type }, { rootValue: { flags, backend = backendReal }}) => {
+			resolve: (concept, { from, limit, genres, type, count, since }, { rootValue: { flags, backend = backendReal }}) => {
 				const id = concept.id || concept.idV1 || concept.uuid;
-				return backend(flags).capi.search('metadata.idV1', id, { from, limit, genres, type });
+				return backend(flags).capi.search('metadata.idV1', id, { from, limit, genres, type, count, since});
 			}
 		}
 	})

--- a/test/server/lib/backend-adapters/capi.test.js
+++ b/test/server/lib/backend-adapters/capi.test.js
@@ -53,7 +53,7 @@ describe('CAPI', () => {
 
 			return capi.content(['content-one', 'content-two'])
 				.then(() => {
-					cached.alwaysCalledWith('capi.content.content-one_content-two', 50);
+					cached.alwaysCalledWith('capi.content.content-one_content-two', 60).should.be.true;
 				});
 		});
 
@@ -98,7 +98,7 @@ describe('CAPI', () => {
 				.then(list => {
 					list.should.have.length(2);
 					list.should.deep.equal([{ id: 'content-one' }, { id: 'content-two' }]);
-					cached.alwaysCalledWith('capi.lists.73667f46-1a55-11e5-a130-2e7db721f996', 50);
+					cached.alwaysCalledWith('capi.lists.73667f46-1a55-11e5-a130-2e7db721f996', 60).should.be.true;
 					// make sure mock was called
 					fetchMock.called().should.be.true;
 				});

--- a/test/server/lib/backend-adapters/capi.test.js
+++ b/test/server/lib/backend-adapters/capi.test.js
@@ -106,4 +106,85 @@ describe('CAPI', () => {
 
 	});
 
+	describe('#search', () => {
+
+		before(() => {
+			fetchMock.mock(
+				new RegExp('https://[^/]*/v3_api_v2/item/_search'),
+				{
+					hits: {
+						total: 1,
+						hits: [
+							{
+								_source: {
+									id: 'topic1'
+								}
+							}
+						]
+					}
+				}
+			);
+		});
+
+		after(() => {
+			fetchMock.restore();
+		});
+
+		it('should be able to fetch content', () => {
+			const cache = {cached: cachedSpy()};
+			const capi = new CAPI(cache);
+
+			return capi.search('metadata.idV1', 'topicId', {count: 50, since: '2016-03-21'})
+				.then(content => {
+					const expectedResult = [{id: 'topic1'}];
+					expectedResult.total = 1;
+					content.should.eql(expectedResult);
+				});
+		});
+
+		it('should use correct cache key and ttl when a single conceptID is specified', () => {
+			const cached = cachedSpy();
+			const cache = {cached};
+			const capi = new CAPI(cache);
+
+			return capi.search('metadata.idV1', 'topicId', {count: 50, since: '2016-03-21'})
+				.then(() => {
+					cached.alwaysCalledWith('capi.search.metadata.idV1:topicId:since_2016-03-21:count_50', 600).should.be.true;
+				});
+		});
+
+		it('should use correct cache key and ttl when multiple conceptIDs are specified', () => {
+			const cached = cachedSpy();
+			const cache = {cached};
+			const capi = new CAPI(cache);
+
+			return capi.search('metadata.idV1', ['topicId1', 'topicId2', 'topicId3'], {count: 50, since: '2016-03-21'})
+				.then(() => {
+					cached.alwaysCalledWith('capi.search.metadata.idV1:topicId1,topicId2,topicId3:since_2016-03-21:count_50', 600).should.be.true;
+				});
+		});
+
+		it('should handle empty response from CAPI', () => {
+			fetchMock.reMock(
+				new RegExp('https://[^/]*/v3_api_v2/item/_search'),
+				{
+					hits: {
+						total: 0,
+						hits: []
+					}
+				}
+			);
+			const cache = {cached: cachedSpy()};
+			const capi = new CAPI(cache);
+
+			return capi.search('metadata.idV1', 'topicId', {count: 50, since: '2016-03-21'})
+				.then(content => {
+					const expectedResult = [];
+					expectedResult.total = 0;
+					content.should.eql(expectedResult);
+				});
+		});
+
+	});
+
 });

--- a/test/server/lib/schema.test.js
+++ b/test/server/lib/schema.test.js
@@ -191,4 +191,37 @@ describe('Schema', () => {
 		});
 
 	});
+
+	describe('Concepts', () => {
+
+		it('should be able to fetch', () => {
+
+			const thingsStub = sinon.stub();
+			thingsStub.returns(Promise.resolve(
+				{items: [
+					{id: 'abc', taxonomy: 'foo', name: 'One'},
+					{id: 'def', taxonomy: 'bar', name: 'Two'}
+				]}));
+			const backend = () => ({
+				capi: {
+					things: thingsStub
+				}
+			});
+			const query = `
+				query Concepts {
+					concepts(ids: ["sdfjksdjfh","idauoiausyi"]) {
+						name
+						url
+					}
+				}
+			`;
+
+			return graphql(schema, query, { backend })
+				.then(({ data }) => {
+					data.concepts.length.should.eq(2);
+					expect(data.concepts[0]).to.deep.equal({ name: 'One', url: '/stream/fooId/abc' });
+					expect(data.concepts[1]).to.deep.equal({ name: 'Two', url: '/stream/barId/def' });
+				});
+		});
+	});
 });


### PR DESCRIPTION
#### Summary
- Add query to get concepts by concept IDs: `concepts(ids: [String])`
- Add optional parameters to capi search: `since` for filtering articles after date, `count` for overriding the default of 10 results returned by capi search
- Add `articleCount` property to `Concept` model. Returns number of articles tagged with concept  published after `since` parameter. `since` defaults to 1 week. The maximum value of `articleCount` is 100. This is to limit the size of the required capi searches.

#### Implementation notes
I'm caching the capi searches for `articleCount` separately from the normal searches. This is to avoid needlessly caching 100-article results for every topic that appears in a myFT card. Happy to debate this decision. 

#### To do

- [x] Write some tests for the capi adapter changes

@ironsidevsquincy @phamann @keirog