### PR TITLE
Add new 'Collection' type and 'collections()' endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel-plugin-transform-es2015-destructuring": "^6.3.13",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.3.13",
     "babel-plugin-transform-es2015-parameters": "^6.3.13",
+    "babel-plugin-transform-es2015-spread": "^6.6.5",
     "babel-register": "^6.3.13",
     "body-parser": "^1.13.3",
     "cookie-parser": "^1.4.0",

--- a/server/lib/backend-adapters/bertha.js
+++ b/server/lib/backend-adapters/bertha.js
@@ -1,0 +1,19 @@
+export default class {
+	constructor (cache) {
+		this.type = 'bertha';
+		this.cache = cache;
+	}
+
+	get(sheetKey, sheetName, ttl = 60 * 10) {
+		const cacheKey = `${this.type}.sheet.${sheetKey}.${sheetName}`;
+		console.log(`FETCHING CACHED BERTHA: ${cacheKey}`);
+		return this.cache.cached(cacheKey, ttl, () => {
+			console.log('BERTHA CACHE MISS');
+			return fetch(`https://bertha.ig.ft.com/view/publish/gss/${sheetKey}/${sheetName}`, {
+				method: 'get',
+				headers: { 'Content-Type': 'application/json' }
+			})
+			.then(r => r.json())
+		});
+	}
+}

--- a/server/lib/backend-adapters/bertha.js
+++ b/server/lib/backend-adapters/bertha.js
@@ -6,14 +6,12 @@ export default class {
 
 	get(sheetKey, sheetName, ttl = 60 * 10) {
 		const cacheKey = `${this.type}.sheet.${sheetKey}.${sheetName}`;
-		console.log(`FETCHING CACHED BERTHA: ${cacheKey}`);
 		return this.cache.cached(cacheKey, ttl, () => {
-			console.log('BERTHA CACHE MISS');
 			return fetch(`https://bertha.ig.ft.com/view/publish/gss/${sheetKey}/${sheetName}`, {
 				method: 'get',
 				headers: { 'Content-Type': 'application/json' }
 			})
-			.then(r => r.json())
+			.then(r => r.json());
 		});
 	}
 }

--- a/server/lib/backend-adapters/index.js
+++ b/server/lib/backend-adapters/index.js
@@ -10,6 +10,7 @@ import Video from './video';
 import PopularAPI from './popular-api';
 import Myft from './myft';
 import TodaysTopics from './todays-topics';
+import Bertha from './bertha';
 
 import Cache from '../cache';
 
@@ -25,6 +26,7 @@ const myft = new Myft(memCache);
 const popularApi = new PopularAPI(memCache);
 const video = new Video(memCache);
 const todaysTopics = new TodaysTopics(memCache);
+const bertha = new Bertha(memCache);
 
 export default (flags = {}) => ({
 	capi: flags.mockFrontPage ? mockCapi : capi,
@@ -34,5 +36,6 @@ export default (flags = {}) => ({
 	myft,
 	popularApi,
 	video,
-	todaysTopics
+	todaysTopics,
+	bertha
 });

--- a/server/lib/identity.js
+++ b/server/lib/identity.js
@@ -1,0 +1,1 @@
+export default (val) => val;

--- a/server/lib/types/collections.js
+++ b/server/lib/types/collections.js
@@ -1,8 +1,10 @@
 import { GraphQLString, GraphQLInt, GraphQLList, GraphQLObjectType } from 'graphql';
 
-import { Content } from './content';
+import { Content, Concept } from './content';
 import { ContentType } from './basic';
 import backendReal from '../backend-adapters/index';
+import moment from 'moment';
+import identity from '../identity';
 
 const contentToUiid = content => content.id.replace(/http:\/\/api\.ft\.com\/things?\//, '');
 
@@ -74,4 +76,39 @@ const List = new GraphQLObjectType({
 	}
 });
 
-export { Page, List };
+const Collection = new GraphQLObjectType({
+	name: 'Collection',
+	description: 'Abstract collection of concepts',
+	fields: {
+		title: {
+			type: GraphQLString
+		},
+		concepts: {
+			type: new GraphQLList(Concept),
+			description: 'Concepts'
+		},
+		articleCount: {
+			type: GraphQLInt,
+			description: `
+				Approximate number of articles published with this concept since the given date, up to a
+				maximum value of count (default date is 1 week, default count is 100)`,
+			args: {
+				since: {
+					type: GraphQLString,
+					defaultValue: moment().subtract(7, 'days').format('YYYY-MM-DD')
+				},
+				count: {
+					type: GraphQLInt,
+					defaultValue: 100
+				}
+			},
+			resolve: (collection, { since, count }, { rootValue: { flags, backend = backendReal }}) => {
+				return Promise.all(collection.concepts.map(c => c.id).map(id =>
+					backend(flags).capi.searchCount('metadata.idV1', id, { count, since})
+				)).then(counts => counts.filter(identity).reduce((a, b) => a + b, 0));
+			}
+		}
+	}
+});
+
+export { Page, List, Collection };

--- a/server/setup.js
+++ b/server/setup.js
@@ -4,6 +4,7 @@ require('babel-register')({
 		'array-includes',
 		'transform-es2015-destructuring',
 		'transform-es2015-modules-commonjs',
-		'transform-es2015-parameters'
+		'transform-es2015-parameters',
+		'transform-es2015-spread'
 	]
 });


### PR DESCRIPTION
As discussed in person, this adds a new `Collection` type which models a collection of concepts and their aggregate article count. This is an experimental data model for new myFT collection cards, therefore the data is coming from a bertha spreadsheet for easy editing before we invest time modelling properly in CAPI.

- Add bertha backend
- Add `Collection` type
- Add `collections()` end point to fetch current list of collections

/cc @ironsidevsquincy @laurieboyes 