### PR TITLE
gracefully handle missing article in todays topics

### DIFF
--- a/server/lib/backend-adapters/todays-topics.js
+++ b/server/lib/backend-adapters/todays-topics.js
@@ -19,9 +19,15 @@ export default class {
 			const be = backend(flags);
 			const args = { from, limit, genres, type };
 			return Promise.all([
-				be.capi.page(sources[`${region}Top`].uuid).then(p => be.capi.content(p.items, args)).then(c => c.map(c => getPrimaryTag(c.metadata))),
-				be.capi.page(sources.opinion.uuid, sources.opinion.sectionsId).then(p => be.capi.content(p.items, args)).then(c => c.map(c => getPrimaryTag(c.metadata))),
-				be.capi.list(sources.editorsPicks.uuid).then(r => be.capi.content(r.items.map(i => i.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args)).then(c => c.map(c => getPrimaryTag(c.metadata)))
+				be.capi.page(sources[`${region}Top`].uuid)
+					.then(p => be.capi.content(p.items, args))
+					.then(c => c.map(c => getPrimaryTag(c.metadata))),
+				be.capi.page(sources.opinion.uuid, sources.opinion.sectionsId)
+					.then(p => p ? be.capi.content(p.items, args) : [])
+					.then(c => c.map(c => getPrimaryTag(c.metadata))),
+				be.capi.list(sources.editorsPicks.uuid)
+					.then(r => be.capi.content(r.items.map(i => i.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args))
+					.then(c => c.map(c => getPrimaryTag(c.metadata)))
 			]).then((data) => {
 				//Flatten results
 				const tags = data.reduce((res, item) => res.concat(item), []).filter(t => t);


### PR DESCRIPTION
The main change here is the ternary on line 26.

This article is coming through in today's topics but doesn't seem to exist in CAPI: bc81b5bc-1995-11e5-a130-2e7db721f996