### PR TITLE
Adds a generic page query

### DIFF
--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -351,6 +351,17 @@ const queryType = new GraphQLObjectType({
 						return be.capi.content(articlesUuids)
 					});
 			}
+		},
+		page: {
+			type: Page,
+			args: {
+				uuid: {
+					type: GraphQLString
+				}
+			},
+			resolve: (root, { uuid }, { rootValue: { flags, backend = backendReal }}) => {
+				return backend(flags).capi.page(uuid);
+			}
 		}
 	}
 });

--- a/test/server/lib/schema.test.js
+++ b/test/server/lib/schema.test.js
@@ -309,4 +309,32 @@ describe('Schema', () => {
 				});
 		});
 	});
+
+	describe('Page', () => {
+
+		it('should be able to fetch', () => {
+			const pageStub = sinon.stub();
+			pageStub.returns({ title: 'UK Stories', url: '1234' });
+			const backend = () => ({
+				capi: {
+					page: pageStub
+				}
+			});
+			const query = `
+				query Page {
+					page(uuid: "2836ebbe-cd26-11de-a748-00144feabdc0") {
+						url
+						title
+					}
+				}
+			`;
+
+			return graphql(schema, query, { backend })
+				.then(({ data }) => {
+					data.page.title.should.equal('UK Stories');
+					data.page.url.should.equal('1234');
+				})
+		});
+
+	});
 });


### PR DESCRIPTION
This allows for querying of any page that you have a `uuid` for.

```
query FrontPage {
  ukSectionPage: page(uuid: "2836ebbe-cd26-11de-a748-00144feabdc0") {
    items(limit: 20) {
      id
      title
    }
  }
}

```

/cc @ironsidevsquincy 