### PR TITLE
added isVideo check

### DIFF
--- a/server/lib/types/content.js
+++ b/server/lib/types/content.js
@@ -240,7 +240,7 @@ const Article = new graphql.GraphQLObjectType({
 		},
 		isVideo: {
 			type: graphql.GraphQLBoolean,
-			resolve: content => content.provenance.some(item => /brightcove/.test(item))
+			resolve: content => content.provenance.some(item => /brightcove/.test(item)) && content.url.includes('video.ft.com')
 		},
 		videoId: {
 			type: graphql.GraphQLString,


### PR DESCRIPTION
@andygnewman @i-like-robots 

This was incorrectly tagging articles that **_have_** videos as ones that **_are_** videos. This fix ensures it is only tagged if it **_is_** a video now.