### PR TITLE
Dont cache empty data

### DIFF
--- a/server/lib/backend-adapters/bertha.js
+++ b/server/lib/backend-adapters/bertha.js
@@ -32,6 +32,7 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((get = []) => get)
 	}
 }

--- a/server/lib/backend-adapters/bertha.js
+++ b/server/lib/backend-adapters/bertha.js
@@ -29,7 +29,7 @@ export default class {
 				})
 				.catch(err => {
 					logger.error('Failed getting a bertha sheet', err);
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);

--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -105,7 +105,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((page = {}) => page);
 	}
 
 	search (termName, termValue, { from, limit, since, genres, type, ttl = 60 * 10 } = {}) {
@@ -118,7 +119,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((search = []) => search);
 	}
 
 	// searchCount is separate from search so that we can look a long way back just for the sake of counting articles
@@ -136,7 +138,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((searchCount = 0) => searchCount);
 	}
 
 	content (uuids, { from, limit, genres, type, ttl = 60 } = { }) {
@@ -152,6 +155,7 @@ export default class {
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((content = []) => content)
 			.then(filterContent({ from, limit, genres, type }, resolveContentType));
 	}
 
@@ -190,7 +194,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((list = {}) => list);
 	}
 
 	listOfType (type, concept, { ttl = 60 } = { }) {
@@ -213,7 +218,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((listOfType = null) => listOfType);
 	}
 
 	things (uuids, { type = 'idV1', ttl = 60 * 10 } = { }) {
@@ -230,6 +236,7 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((things = []) => things);
 	}
 }

--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -102,7 +102,7 @@ export default class {
 				}))
 				.catch(err => {
 					logger.error('Failed getting a CAPI page', err, { uuid });
-					return {}
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -115,7 +115,7 @@ export default class {
 				.then(results => results.slice())
 				.catch(err => {
 					logger.error('Failed making a CAPI search', err, { term_name: termName, term_value: termValue });
-					return []
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -133,7 +133,7 @@ export default class {
 				.then(results => results.total || 0)
 				.catch(err => {
 					logger.error('Failed making a CAPI search count', err, { term_name: termName, term_value: termValue });
-					return 0;
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -148,7 +148,7 @@ export default class {
 			})
 				.catch(err => {
 					logger.error('Failed getting CAPI content', err, { uuids });
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)

--- a/server/lib/backend-adapters/capi.js
+++ b/server/lib/backend-adapters/capi.js
@@ -187,7 +187,7 @@ export default class {
 				}))
 				.catch(err => {
 					logger.error('Failed getting a CAPI list', err, { uuid });
-					return {};
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -210,7 +210,7 @@ export default class {
 				})
 				.catch(err => {
 					logger.error('Failed getting a CAPI list-of-type', err, { type, concept });
-					return null;
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -227,7 +227,7 @@ export default class {
 				.then(results => results.items || [])
 				.catch(err => {
 					logger.error('Failed getting things from CAPI', err, { uuids });
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);

--- a/server/lib/backend-adapters/fast-ft.js
+++ b/server/lib/backend-adapters/fast-ft.js
@@ -29,6 +29,7 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((fetch = []) => fetch);
 	}
 }

--- a/server/lib/backend-adapters/fast-ft.js
+++ b/server/lib/backend-adapters/fast-ft.js
@@ -26,7 +26,7 @@ export default class {
 				.then(results => results.slice())
 				.catch(err => {
 					logger.error('Failed getting fastFT content', err);
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);

--- a/server/lib/backend-adapters/hui.js
+++ b/server/lib/backend-adapters/hui.js
@@ -38,7 +38,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((topics = []) => topics);
 	}
 
 }

--- a/server/lib/backend-adapters/hui.js
+++ b/server/lib/backend-adapters/hui.js
@@ -21,11 +21,11 @@ export default class {
 				.hui({ model: 'content', industry, position, sector, country, period })
 				.catch(err => {
 					logger.error('Failed getting hui content', err);
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
-			.then(articles => sliceList(articles, { from, limit }));
+			.then((articles = []) => sliceList(articles, { from, limit }));
 	}
 
 	topics ({ industry, position, sector, country, period = 'last-1-week', ttl = 60 * 60 * 60 }) {
@@ -35,7 +35,7 @@ export default class {
 				.hui({ model: 'annotations', industry, position, sector, country, period })
 				.catch(err => {
 					logger.error('Failed getting hui topics', err);
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);

--- a/server/lib/backend-adapters/liveblog.js
+++ b/server/lib/backend-adapters/liveblog.js
@@ -42,11 +42,11 @@ export default class {
 				.then(liveblog => this.parse(liveblog))
 				.catch(err => {
 					logger.error('Failed fetching a liveblog', err);
-					return { updates: [] };
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
-			.then(liveBlogInfo => ({
+			.then((liveBlogInfo = { updates: [] }) => ({
 				status: liveBlogInfo.status,
 				updates: limit ? liveBlogInfo.updates.slice(0, limit) : liveBlogInfo.updates
 			}));

--- a/server/lib/backend-adapters/myft.js
+++ b/server/lib/backend-adapters/myft.js
@@ -52,7 +52,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((topics = []) => topics;
 	}
 
 	getMostReadTopics ({ limit = 10, ttl = 60 }) {
@@ -66,7 +67,8 @@ export default class {
 				});
 		};
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((topics = []) => topics);
 	}
 
 	getMostFollowedTopics ({ limit = 10, ttl = 60 }) {
@@ -79,6 +81,7 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+		.then((topics = []) => topics);
 	}
 }

--- a/server/lib/backend-adapters/myft.js
+++ b/server/lib/backend-adapters/myft.js
@@ -19,7 +19,7 @@ export default class {
 					if (err.message !== 'No user data exists') {
 						logger.error('Failed getting all relationships from myFT', err, { uuid, relationship, model });
 					}
-					return [];
+					throw err;
 				});
 
 		// NOTE: emulate a 0 sec cache, as setex doesn't allow a zero value
@@ -33,7 +33,7 @@ export default class {
 				.then(results => results.viewed.filter(nonEmpty))
 				.catch(err => {
 					logger.error('Failed getting viewed from myFT', err, { uuid });
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -49,7 +49,7 @@ export default class {
 					if (err.message !== 'No user data exists') {
 						logger.error('Failed getting recommended topics from myFT', err, { uuid });
 					}
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);
@@ -62,7 +62,7 @@ export default class {
 				.then(results => results.items.filter(nonEmpty))
 				.catch(err => {
 					logger.error('Failed getting most read topics from myFT', err);
-					return [];
+					throw err;
 				});
 		};
 
@@ -76,7 +76,7 @@ export default class {
 				.then(results => results.items.filter(nonEmpty))
 				.catch(err => {
 					logger.error('Failed getting most followed topics from myFT', err);
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher);

--- a/server/lib/backend-adapters/myft.js
+++ b/server/lib/backend-adapters/myft.js
@@ -23,7 +23,13 @@ export default class {
 				});
 
 		// NOTE: emulate a 0 sec cache, as setex doesn't allow a zero value
-		return ttl === 0 ? fetcher() : this.cache.cached(cacheKey, ttl, fetcher);
+		if (ttl === 0) {
+			return fetcher()
+				.catch(() => [])
+		} else {
+			return this.cache.cached(cacheKey, ttl, fetcher)
+				.then((relationships = []) => relationships)
+		}
 	}
 
 	getViewed (uuid, { limit = 10, ttl = 60 }) {
@@ -36,7 +42,8 @@ export default class {
 					throw err;
 				});
 
-		return this.cache.cached(cacheKey, ttl, fetcher);
+		return this.cache.cached(cacheKey, ttl, fetcher)
+			.then((viewed = []) => viewed);
 	}
 
 	getRecommendedTopics (uuid, { limit = 10, ttl = 60 }) {
@@ -53,7 +60,7 @@ export default class {
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
-			.then((topics = []) => topics;
+			.then((topics = []) => topics)
 	}
 
 	getMostReadTopics ({ limit = 10, ttl = 60 }) {

--- a/server/lib/backend-adapters/popular-api.js
+++ b/server/lib/backend-adapters/popular-api.js
@@ -26,11 +26,11 @@ export default class {
 				})
 				.catch(err => {
 					logger.error('Failed getting popular api topics', err);
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
-			.then(topics => sliceList(topics, { from, limit }));
+			.then((topics = []) => sliceList(topics, { from, limit }));
 	}
 
 	articles ({ from, limit, concept, ttl = 60 * 10 } = {}) {
@@ -51,10 +51,10 @@ export default class {
 					.then(json => (json.articles || []).map(article => article.uuid))
 					.catch(err => {
 						logger.error('Failed getting popular api articles', err);
-						return [];
+						throw err;
 					});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
-			.then(articles => sliceList(articles, { from, limit }));
+			.then((articles = []) => sliceList(articles, { from, limit }));
 	}
 }

--- a/server/lib/backend-adapters/video.js
+++ b/server/lib/backend-adapters/video.js
@@ -36,10 +36,10 @@ export default class {
 				.then(({ items: videos }) => videos.filter(video => video.renditions.length > 0))
 				.catch(err => {
 					logger.error('Failed fetching video playlist', err, { playlist: id });
-					return [];
+					throw err;
 				});
 
 		return this.cache.cached(cacheKey, ttl, fetcher)
-			.then(videos => sliceList(videos, { from, limit }));
+			.then((videos = []) => sliceList(videos, { from, limit }));
 	}
 }

--- a/test/server/lib/backend-adapters/capi.test.js
+++ b/test/server/lib/backend-adapters/capi.test.js
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
-import chai, { expect } from 'chai';
+import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 
@@ -149,7 +149,7 @@ describe('CAPI', () => {
 			before(() => {
 				fetchMock.mock(
 					new RegExp('https://[^\.]*.ft.com/lists'),
-					404
+					{ status: 404, body: 'Not Found'}
 				);
 			});
 
@@ -162,12 +162,7 @@ describe('CAPI', () => {
 				const cache = { cached };
 				const capi = new CAPI(cache);
 
-				return capi.listOfType(listType, concept)
-					.then(list => {
-						expect(list).to.be.null;
-						// make sure mock was called
-						fetchMock.called().should.be.true;
-					});
+				return capi.listOfType(listType, concept).should.be.rejectedWith('COCO list-of-type responded with "Not Found" (404)')
 			});
 
 		});


### PR DESCRIPTION
@ironsidevsquincy @andygnewman 

So I tested this locally (in the playground*) with videos and it was cacheing the empty array. It would cache and then every new request would just return the cached array and wouldn't attempt to fetch any new data until the `ttl` had expired and a new request was made. 

After these changes, once the cached data had expired each time I made a new request it would try and fetch the data from the source, if that then became successful it would cache it.

I'm reasonably confident that this should work in all the places I've made changes. But maybe more local testing should happen so the whole world doesn't fall over.

There was a test in `capi.test.js` but I wonder whether there should be some unit tests for all the others. Thoughts?

_\* If the video fetch failed while trying to locally run the front-page it would blow up completely rather than just not rendering the video component, like the live site. If you can think of any suggestions as to fix that I'm all ears._