### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 dump.rdb
 
 /.editorconfig
-/.env
+*.env*
 /.scss-lint.yml
 /npm-debug.log*
 


### PR DESCRIPTION
@ironsidevsquincy 

`make install` wasn't creating a `.env` file because it expects this format