### PR TITLE
Ensure cache fetch promise is deleted if no response data returned

### DIFF
--- a/server/lib/caches/mem-cache.js
+++ b/server/lib/caches/mem-cache.js
@@ -69,6 +69,7 @@ export default class {
 		this.currentRequests[key] = fetcher()
 		.then((it) => {
 			if(!it) {
+				delete this.currentRequests[key];
 				return;
 			}
 			let expireTime = now + ttl;

--- a/server/lib/caches/redis-cache.js
+++ b/server/lib/caches/redis-cache.js
@@ -57,6 +57,7 @@ export default class {
 		return this.currentRequests[key] = fetcher()
 			.then(res => {
 				if (res === undefined) {
+					delete this.currentRequests[key];
 					return;
 				}
 				metrics.histogram(`cache.${metricsKey}.fresh.time`, Date.now() - start)


### PR DESCRIPTION
To prevent requesting the same data from a backend multiple times within a short period of time (i.e. if two identical requests came in within a couple of ms) we memoize the fetch promise in an internal object and return the original promise value if the key exists. We then purge the key once the backend has resolved with data or failed, ready for the next request of the same key to start a fresh promise. 

It turns out we are not correctly purging the key if the backend response was successful but returned no data. For instance, a 404 if the user has no myFT data :wink: 

This could potentially lead to the `currentRequests` object bloating and causing a memory leak. It could also mean a request could forever result in a resolved promise with no data.

This - quite simply - fixes that.