### PR TITLE
Add opinion & highlights variants

### DIFF
--- a/server/config/sources.js
+++ b/server/config/sources.js
@@ -20,6 +20,12 @@ const sources = {
 	opinion: {
 		uuid: 'bc81b5bc-1995-11e5-a130-2e7db721f996'
 	},
+	ukOpinion: {
+		uuid: ''
+	},
+	usOpinion: {
+		uuid: ''
+	},
 	markets: {
 		uuid: '011debcc-cd26-11de-a748-00144feabdc0'
 	},

--- a/server/config/sources.js
+++ b/server/config/sources.js
@@ -17,14 +17,11 @@ const sources = {
 	fastFt: {
 		idV1: 'NTlhNzEyMzMtZjBjZi00Y2U1LTg0ODUtZWVjNmEyYmU1NzQ2-QnJhbmRz'
 	},
-	opinion: {
+	ukOpinion: {
 		uuid: 'bc81b5bc-1995-11e5-a130-2e7db721f996'
 	},
-	ukOpinion: {
-		uuid: ''
-	},
 	usOpinion: {
-		uuid: ''
+		uuid: 'cd4a2e0a-91f9-11e6-a72e-b428cb934b78'
 	},
 	markets: {
 		uuid: '011debcc-cd26-11de-a748-00144feabdc0'
@@ -44,8 +41,11 @@ const sources = {
 	videos: {
 		id: '69917354001' // BrightCove ID
 	},
-	editorsPicks: {
+	ukEditorsPicks: {
 		uuid: '73667f46-1a55-11e5-a130-2e7db721f996'
+	},
+	usEditorsPicks: {
+		uuid: 'cd36f40c-91f9-11e6-a72e-b428cb934b78'
 	},
 	brexitPrimary: {
 		uuid: 'b2f7f28c-1114-11e6-91da-096d89bd2173'

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -87,6 +87,16 @@ const queryType = new GraphQLObjectType({
 			resolve: (root, _, { flags, backend = backendReal }) =>
 				backend(flags).capi.list(sources.opinion.uuid)
 		},
+		ukOpinion: {
+			type: List,
+			resolve: (root, _, { flags, backend = backendReal }) =>
+				backend(flags).capi.list(sources.ukOpinion.uuid)
+		},
+		intOpinion: {
+			type: List,
+			resolve: (root, _, { flags, backend = backendReal }) =>
+				backend(flags).capi.list(sources.intOpinion.uuid)
+		},
 		lifestyle: {
 			type: List,
 			resolve: (root, _, { flags, backend = backendReal }) =>

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -79,24 +79,21 @@ const queryType = new GraphQLObjectType({
 		},
 		editorsPicks: {
 			type: List,
-			resolve: (root, _, { flags, backend = backendReal }) =>
-				backend(flags).capi.list(sources.editorsPicks.uuid)
+			args: {
+				region: {
+					type: new GraphQLNonNull(Region),
+					defaultValue: 'uk'
+				}
+			},
+			resolve: (root, { region }, { flags, backend = backendReal }) =>
+			backend(flags).capi.page(sources[`${region}EditorsPicks`].uuid)
 		},
 		opinion: {
 			type: List,
-			resolve: (root, _, { flags, backend = backendReal }) =>
-				backend(flags).capi.list(sources.opinion.uuid)
-		},
-		oldOpinion: {
-			type: List,
-			resolve: (root, _, { flags, backend = backendReal }) =>
-				backend(flags).capi.list(sources.opinion.uuid)
-		},
-		newOpinion: {
-			type: List,
 			args: {
 				region: {
-					type: new GraphQLNonNull(Region)
+					type: new GraphQLNonNull(Region),
+					defaultValue: 'uk'
 				}
 			},
 			resolve: (root, { region }, { flags, backend = backendReal }) =>

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -87,6 +87,11 @@ const queryType = new GraphQLObjectType({
 			resolve: (root, _, { flags, backend = backendReal }) =>
 				backend(flags).capi.list(sources.opinion.uuid)
 		},
+		oldOpinion: {
+			type: List,
+			resolve: (root, _, { flags, backend = backendReal }) =>
+				backend(flags).capi.list(sources.opinion.uuid)
+		},
 		newOpinion: {
 			type: List,
 			args: {

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -87,15 +87,15 @@ const queryType = new GraphQLObjectType({
 			resolve: (root, _, { flags, backend = backendReal }) =>
 				backend(flags).capi.list(sources.opinion.uuid)
 		},
-		ukOpinion: {
+		newOpinion: {
 			type: List,
-			resolve: (root, _, { flags, backend = backendReal }) =>
-				backend(flags).capi.list(sources.ukOpinion.uuid)
-		},
-		intOpinion: {
-			type: List,
-			resolve: (root, _, { flags, backend = backendReal }) =>
-				backend(flags).capi.list(sources.intOpinion.uuid)
+			args: {
+				region: {
+					type: new GraphQLNonNull(Region)
+				}
+			},
+			resolve: (root, { region }, { flags, backend = backendReal }) =>
+				backend(flags).capi.page(sources[`${region}Opinion`].uuid)
 		},
 		lifestyle: {
 			type: List,

--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -81,23 +81,23 @@ const queryType = new GraphQLObjectType({
 			type: List,
 			args: {
 				region: {
-					type: new GraphQLNonNull(Region),
+					type: Region,
 					defaultValue: 'uk'
 				}
 			},
 			resolve: (root, { region }, { flags, backend = backendReal }) =>
-			backend(flags).capi.page(sources[`${region}EditorsPicks`].uuid)
+				backend(flags).capi.list(sources[`${region}EditorsPicks`].uuid)
 		},
 		opinion: {
 			type: List,
 			args: {
 				region: {
-					type: new GraphQLNonNull(Region),
+					type: Region,
 					defaultValue: 'uk'
 				}
 			},
 			resolve: (root, { region }, { flags, backend = backendReal }) =>
-				backend(flags).capi.page(sources[`${region}Opinion`].uuid)
+				backend(flags).capi.list(sources[`${region}Opinion`].uuid)
 		},
 		lifestyle: {
 			type: List,


### PR DESCRIPTION
TODO:
- [x] Update sources with uuids

The reason I have duplicated `opinion` with `oldOpinion` is so that we should have no downtime. See below

**Release plan:**
- [x] Merge this (once TODOs complete)
- [ ] Switch `next-front-page` query to use `region` parameter
- [ ] Go to the pub 🍺 


/cc @ironsidevsquincy can you just clarify that this release plan is accurate. Context: Mus wants to have region specific opinion lists.