### PR TITLE
move to new image service

### DIFF
--- a/server/lib/types/media/image.js
+++ b/server/lib/types/media/image.js
@@ -13,7 +13,7 @@ const Image = new graphql.GraphQLObjectType({
 				}
 			},
 			resolve: (image, { width }) =>
-				`//next-geebee.ft.com/image/v1/images/raw/${encodeURIComponent(image.url)}?source=next&fit=scale-down&width=${width}`
+				`https:////www.ft.com/__origami/service/image/v2/images/raw/${encodeURIComponent(image.url)}?source=next&fit=scale-down&width=${width}`
 		},
 		rawSrc: {
 			type: graphql.GraphQLString,


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2